### PR TITLE
Add create experiment as tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 node_modules/
 .env
+.claude

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A hammer icon should appear in the chat window, indicating that your GrowthBook 
   - `get_experiments`: List all experiments in GrowthBook.
   - `get_experiment`: Fetch details for a specific experiment by ID.
   - `get_attributes`: List all user attributes tracked in GrowthBook (useful for targeting).
+  - `create_experiment`: Creates a feature-flag based experiment.
 
 - **Environments**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "access": "public",
   "homepage": "https://github.com/growthbook/growthbook-mcp",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "license": "MIT",
   "packageManager": "pnpm@10.6.1",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2",
-    "zod": "^3.22.4"
+    "@modelcontextprotocol/sdk": "^1.13.1",
+    "env-paths": "^3.0.0",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.4",
     "typescript": "^5.8.3"
   },
   "type": "module"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,31 +9,37 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.10.2
-        version: 1.10.2
+        specifier: ^1.13.1
+        version: 1.13.1
+      env-paths:
+        specifier: ^3.0.0
+        version: 3.0.0
       zod:
-        specifier: ^3.22.4
-        version: 3.24.3
+        specifier: ^3.25.67
+        version: 3.25.67
     devDependencies:
       '@types/node':
-        specifier: ^22.15.3
-        version: 22.15.3
+        specifier: ^24.0.4
+        version: 24.0.4
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
 
 packages:
 
-  '@modelcontextprotocol/sdk@1.10.2':
-    resolution: {integrity: sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==}
+  '@modelcontextprotocol/sdk@1.13.1':
+    resolution: {integrity: sha512-8q6+9aF0yA39/qWT/uaIj6zTpC+Qu07DnN/lb9mjoquCJsAh6l3HyYqc9O3t2j7GilseOQOQimLg7W3By6jqvg==}
     engines: {node: '>=18'}
 
-  '@types/node@22.15.3':
-    resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
+  '@types/node@24.0.4':
+    resolution: {integrity: sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
@@ -75,8 +81,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -99,6 +105,10 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -118,23 +128,29 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventsource-parser@3.0.1:
-    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
+  eventsource-parser@3.0.3:
+    resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
+    engines: {node: '>=20.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  eventsource@3.0.6:
-    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
-    engines: {node: '>=18.0.0'}
-
-  express-rate-limit@7.5.0:
-    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
     engines: {node: '>= 16'}
     peerDependencies:
-      express: ^4.11 || 5 || ^5.0.0-beta.1
+      express: '>= 4.11'
 
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
@@ -191,6 +207,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -254,6 +273,10 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -315,6 +338,10 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -328,12 +355,15 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -347,45 +377,53 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  zod-to-json-schema@3.24.5:
-    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+  zod-to-json-schema@3.24.6:
+    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  zod@3.25.67:
+    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
 snapshots:
 
-  '@modelcontextprotocol/sdk@1.10.2':
+  '@modelcontextprotocol/sdk@1.13.1':
     dependencies:
+      ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
-      eventsource: 3.0.6
+      eventsource: 3.0.7
       express: 5.1.0
-      express-rate-limit: 7.5.0(express@5.1.0)
+      express-rate-limit: 7.5.1(express@5.1.0)
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.6(zod@3.25.67)
     transitivePeerDependencies:
       - supports-color
 
-  '@types/node@22.15.3':
+  '@types/node@24.0.4':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.8.0
 
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
       negotiator: 1.0.0
 
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   body-parser@2.2.0:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.0
+      debug: 4.4.1
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -428,7 +466,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.0:
+  debug@4.4.1:
     dependencies:
       ms: 2.1.3
 
@@ -444,6 +482,8 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  env-paths@3.0.0: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -456,13 +496,13 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventsource-parser@3.0.1: {}
+  eventsource-parser@3.0.3: {}
 
-  eventsource@3.0.6:
+  eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.1
+      eventsource-parser: 3.0.3
 
-  express-rate-limit@7.5.0(express@5.1.0):
+  express-rate-limit@7.5.1(express@5.1.0):
     dependencies:
       express: 5.1.0
 
@@ -474,7 +514,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -492,20 +532,24 @@ snapshots:
       router: 2.2.0
       send: 1.2.0
       serve-static: 2.2.0
-      statuses: 2.0.1
+      statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -561,6 +605,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  json-schema-traverse@0.4.1: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -602,6 +648,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  punycode@2.3.1: {}
+
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
@@ -617,7 +665,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -631,7 +679,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -641,7 +689,7 @@ snapshots:
       ms: 2.1.3
       on-finished: 2.4.1
       range-parser: 1.2.1
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -692,6 +740,8 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   toidentifier@1.0.1: {}
 
   type-is@2.0.1:
@@ -702,9 +752,13 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.8.0: {}
 
   unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   vary@1.1.2: {}
 
@@ -714,8 +768,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  zod-to-json-schema@3.24.5(zod@3.24.3):
+  zod-to-json-schema@3.24.6(zod@3.25.67):
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.67
 
-  zod@3.24.3: {}
+  zod@3.25.67: {}

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -1,0 +1,521 @@
+export const FEATURE_FLAG_DOCS = {
+  react: `## React Feature Flag Implementation
+
+### Boolean Feature Flags
+Use \`useFeatureIsOn\` for simple on/off features. \`useFeatureIsOn\` should appear in the component body, not in the return statement/template:
+\`\`\`tsx
+import { useFeatureIsOn } from "@growthbook/growthbook-react";
+
+function LoginPage() {
+  const showNewDesign = useFeatureIsOn("new-login-design");
+  
+  return showNewDesign ? <NewLoginForm /> : <OldLoginForm />;
+}
+\`\`\`
+
+### Feature Values with Defaults
+Use \`useFeatureValue\` when you need specific values. \`useFeatureValue\` should appear in the component body, not in the return statement/template:
+\`\`\`tsx
+import { useFeatureValue } from "@growthbook/growthbook-react";
+
+function Button() {
+  const buttonColor = useFeatureValue("button-color", "blue");
+  const buttonSize = useFeatureValue("button-size", "medium");
+  
+  return (
+    <button 
+      className={\`btn btn-\${buttonColor} btn-\${buttonSize}\`}
+    >
+      Click me
+    </button>
+  );
+}
+\`\`\`
+
+### Declarative Components
+Use feature components for conditional rendering:
+\`\`\`tsx
+import { IfFeatureEnabled, FeatureString } from "@growthbook/growthbook-react";
+
+function HomePage() {
+  return (
+    <div>
+      <h1>
+        <FeatureString feature="site-title" default="Welcome" />
+      </h1>
+      
+      <IfFeatureEnabled feature="promo-banner">
+        <PromoBanner />
+      </IfFeatureEnabled>
+      
+      <IfFeatureEnabled feature="new-checkout" fallback={<OldCheckout />}>
+        <NewCheckout />
+      </IfFeatureEnabled>
+    </div>
+  );
+}
+\`\`\``,
+
+  javascript: `## JavaScript Feature Flag Implementation
+
+### Simple Feature Checks
+Use \`isOn()\` for boolean features:
+\`\`\`javascript
+function renderDashboard() {
+  if (gb.isOn("new-dashboard")) {
+    return renderNewDashboard();
+  }
+  return renderOldDashboard();
+}
+\`\`\`
+
+### Feature Values with Fallbacks
+Use \`getFeatureValue()\` for configuration values:
+\`\`\`javascript
+function configureAPI() {
+  const apiTimeout = gb.getFeatureValue("api-timeout", 5000);
+  const retryCount = gb.getFeatureValue("retry-count", 3);
+  
+  return {
+    timeout: apiTimeout,
+    retries: retryCount
+  };
+}
+\`\`\`
+
+### Detailed Feature Evaluation
+Use \`evalFeature()\` when you need metadata:
+\`\`\`javascript
+function trackFeatureUsage(featureKey) {
+  const result = gb.evalFeature(featureKey);
+  
+  // Track feature usage for analytics
+  analytics.track('feature_evaluated', {
+    feature: featureKey,
+    value: result.value,
+    source: result.source,
+    ruleId: result.ruleId
+  });
+  
+  return result.value;
+}
+\`\`\``,
+
+  vue: `## Vue Feature Flag Implementation
+
+### Composition API
+\`\`\`typescript
+import { ref, watch, inject } from 'vue'
+
+const showBanner = ref(growthbook?.isOn('show-banner'))
+
+// Optional real-time watching
+watch(growthbook, () => {
+  showBanner.value = growthbook?.isOn('show-banner')
+})
+\`\`\`
+
+### Options API
+\`\`\`typescript
+export default {
+  data() {
+    return {
+      showBanner: false
+    }
+  },
+  mounted() {
+    const gb = inject(gbKey)
+    if (gb) {
+      this.showBanner = gb.isOn('show-banner')
+    }
+  }
+}
+\`\`\`
+
+### Template Usage
+\`\`\`html
+<template>
+  <div>
+    <h1 v-if="showBanner">Now you see me!</h1>
+  </div>
+</template>
+\`\`\``,
+
+  python: `## Python Feature Flag Implementation
+
+### Boolean Feature Checks
+Use \`is_on()\` and \`is_off()\` for feature toggles:
+\`\`\`python
+def process_payment(gb, payment_data):
+    if gb.is_on("new-payment-processor"):
+        return new_payment_service.process(payment_data)
+    else:
+        return legacy_payment_service.process(payment_data)
+\`\`\`
+
+### Feature Values with Defaults
+Use \`get_feature_value()\` for configuration:
+\`\`\`python
+def get_api_config(gb):
+    return {
+        'timeout': gb.get_feature_value("api-timeout", 30),
+        'max_retries': gb.get_feature_value("max-retries", 3),
+        'batch_size': gb.get_feature_value("batch-size", 100)
+    }
+\`\`\`
+
+### Detailed Feature Evaluation
+Use \`evalFeature()\` for comprehensive feature info:
+\`\`\`python
+def evaluate_feature_with_tracking(gb, feature_key):
+    result = gb.evalFeature(feature_key)
+    
+    # Log feature evaluation for debugging
+    logger.info(f"Feature {feature_key}: value={result.value}, source={result.source}")
+    
+    return result.value
+\`\`\`
+
+### Web Framework Integration (Django Example)
+\`\`\`python
+def growthbook_middleware(get_response):
+    def middleware(request):
+        # Initialize GrowthBook for each request
+        request.gb = create_growthbook_instance(
+            user_id=getattr(request.user, 'id', None),
+            is_authenticated=request.user.is_authenticated,
+            user_type=getattr(request.user, 'user_type', 'anonymous')
+        )
+        
+        response = get_response(request)
+        return response
+    return middleware
+\`\`\``,
+
+  go: `## Go Feature Flag Implementation
+
+### Basic Feature Evaluation
+\`\`\`go
+// Evaluate a text feature
+buttonColor := client.EvalFeature(context.Background(), "buy-button-color")
+if buttonColor.Value == "blue" {
+    // Perform actions for blue button
+}
+
+// Evaluate a boolean feature
+darkMode := client.EvalFeature(context.Background(), "dark-mode")
+if darkMode.On {
+    // Enable dark mode
+}
+\`\`\`
+
+### Detailed Feature Inspection
+\`\`\`go
+result, err := client.EvalFeature(context.TODO(), "my-feature")
+if err != nil {
+    // Handle error
+}
+
+// Check feature value and source
+if result.On {
+    // Feature is enabled
+}
+
+// Inspect how the feature value was determined
+switch result.Source {
+case gb.DefaultValueResultSource:
+    // Used default value
+case gb.ExperimentResultSource:
+    // Value determined by an experiment
+case gb.ForceResultSource:
+    // Manually forced value
+}
+\`\`\``,
+
+  php: `## PHP Feature Flag Implementation
+
+### Basic Feature Checks
+\`\`\`php
+// Check if a feature is on
+if ($growthbook->isOn("my-feature")) {
+  echo "It's on!";
+}
+
+// Check if a feature is off
+if ($growthbook->isOff("my-feature")) {
+  echo "It's off :(";
+}
+\`\`\`
+
+### Feature Values with Fallback
+\`\`\`php
+// Get feature value with default fallback
+$color = $growthbook->getValue("button-color", "blue");
+echo "<button style='color:\${color}'>Click Me!</button>";
+\`\`\`
+
+### Detailed Feature Result
+\`\`\`php
+$featureResult = $growthbook->getFeature("my-feature");
+
+// Access feature result properties
+$value = $featureResult->value;
+$isOn = $featureResult->on;
+$source = $featureResult->source; // e.g. 'defaultValue', 'experiment'
+\`\`\`
+
+### Inline Experiments
+\`\`\`php
+$exp = Growthbook\\InlineExperiment::create(
+  "my-experiment", 
+  ["red", "blue", "green"]
+);
+
+// Run experiment and get result
+$result = $growthbook->runInlineExperiment($exp);
+echo $result->value; // Will be "red", "blue", or "green"
+\`\`\``,
+
+  ruby: `## Ruby Feature Flag Implementation
+
+### Basic Feature Evaluation
+\`\`\`ruby
+# Check if feature is enabled
+if gb.feature_on?("my-feature")
+  puts "Feature is on!"
+end
+
+# Get feature value with default
+color = gb.get_feature_value("button-color", "blue")
+\`\`\`
+
+### Detailed Feature Results
+\`\`\`ruby
+result = gb.eval_feature("my-feature")
+puts result.value
+puts result.on?
+puts result.source
+\`\`\``,
+
+  java: `## Java Feature Flag Implementation
+
+### Feature State Checks
+\`\`\`java
+// Check if a feature is on/off
+boolean isDarkModeEnabled = growthBook.isOn("dark_mode");
+boolean isFeatureDisabled = growthBook.isOff("feature_key");
+\`\`\`
+
+### Feature Values with Defaults
+\`\`\`java
+// Get feature value with a default
+String welcomeMessage = growthBook.getFeatureValue("welcome_message", "Default Welcome");
+Float pricing = growthBook.getFeatureValue("product_price", 9.99f);
+\`\`\`
+
+### Complex Type Evaluation
+\`\`\`java
+// For complex objects, specify the class for deserialization
+MyConfig config = growthBook.getFeatureValue(
+    "app_config", 
+    defaultConfig, 
+    MyConfig.class
+);
+
+// Detailed feature evaluation
+FeatureResult<Float> result = growthBook.evalFeature("pricing");
+Float value = result.getValue();
+FeatureResultSource source = result.getSource();
+\`\`\``,
+
+  csharp: `## C# Feature Flag Implementation
+
+### Basic Feature Evaluation
+\`\`\`csharp
+// Check if feature is enabled
+if (gb.IsOn("my-feature"))
+{
+    Console.WriteLine("Feature is enabled!");
+}
+
+// Get feature value with default
+var buttonColor = gb.GetFeatureValue("button-color", "blue");
+\`\`\`
+
+### Typed Feature Values
+\`\`\`csharp
+// Get strongly typed feature values
+var maxRetries = gb.GetFeatureValue<int>("max-retries", 3);
+var timeout = gb.GetFeatureValue<double>("timeout-seconds", 30.0);
+\`\`\`
+
+### Feature Result Details
+\`\`\`csharp
+var result = gb.EvalFeature("my-feature");
+Console.WriteLine($"Value: {result.Value}");
+Console.WriteLine($"Source: {result.Source}");
+Console.WriteLine($"On: {result.On}");
+\`\`\``,
+
+  swift: `## Swift Feature Flag Implementation
+
+### Basic Feature Checks
+\`\`\`swift
+// Check if feature is enabled
+if gb.isOn(feature: "dark-mode") {
+    // Enable dark mode
+}
+
+// Get feature value with default
+let buttonColor = gb.getFeatureValue(feature: "button-color", defaultValue: "blue")
+\`\`\`
+
+### Feature Evaluation
+\`\`\`swift
+let result = gb.evalFeature("my-feature")
+print("Value: \\(result.value)")
+print("On: \\(result.on)")
+print("Source: \\(result.source)")
+\`\`\``,
+
+  elixir: `## Elixir Feature Flag Implementation
+
+### Basic Feature Evaluation
+\`\`\`elixir
+# Check if feature is enabled
+case GrowthBook.feature_on?(gb, "my-feature") do
+  true -> IO.puts("Feature is on!")
+  false -> IO.puts("Feature is off")
+end
+
+# Get feature value with default
+button_color = GrowthBook.get_feature_value(gb, "button-color", "blue")
+\`\`\`
+
+### Feature Result Evaluation
+\`\`\`elixir
+result = GrowthBook.eval_feature(gb, "my-feature")
+IO.inspect(result.value)
+IO.inspect(result.on)
+IO.inspect(result.source)
+\`\`\``,
+
+  kotlin: `## Kotlin Feature Flag Implementation
+
+### Basic Feature Checks
+\`\`\`kotlin
+// Get feature and check if enabled
+val feature = gb.feature("dark-mode")
+if (feature.on) {
+    // Enable dark mode
+}
+
+// Check if feature is off
+if (feature.off) {
+    // Feature is disabled
+}
+\`\`\`
+
+### Feature Values
+\`\`\`kotlin
+// Get feature value
+val buttonColor = gb.feature("button-color")
+val colorValue = buttonColor.value
+
+// Direct value access with fallback logic
+val actualColor = if (buttonColor.on) buttonColor.value else "blue"
+\`\`\`
+
+### Feature Result Details
+\`\`\`kotlin
+val feature = gb.feature("my-feature")
+println("Value: \${feature.value}")
+println("On: \${feature.on}")
+println("Off: \${feature.off}")
+println("Source: \${feature.source}")
+\`\`\``,
+
+  flutter: `## Flutter Feature Flag Implementation
+
+### Basic Feature Usage
+\`\`\`dart
+// Check if feature is enabled
+if (gb.isOn('dark-mode')) {
+  // Enable dark mode
+}
+
+// Get feature value with default
+String buttonColor = gb.getFeatureValue('button-color', 'blue');
+\`\`\`
+
+### Widget Integration
+\`\`\`dart
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final showBanner = gb.isOn('show-banner');
+    
+    return Column(
+      children: [
+        if (showBanner) BannerWidget(),
+        MainContent(),
+      ],
+    );
+  }
+}
+\`\`\`
+
+### Feature Result Evaluation
+\`\`\`dart
+GBFeatureResult result = gb.evalFeature('my-feature');
+print('Value: \${result.value}');
+print('On: \${result.on}');
+print('Source: \${result.source}');
+\`\`\``,
+};
+
+export function getFeatureFlagDocs(language: string) {
+  switch (language.toLowerCase()) {
+    case "react":
+    case "tsx":
+    case "jsx":
+      return FEATURE_FLAG_DOCS.react;
+    case "javascript":
+    case "js":
+    case "node":
+      return FEATURE_FLAG_DOCS.javascript;
+    case "vue":
+      return FEATURE_FLAG_DOCS.vue;
+    case "python":
+    case "py":
+      return FEATURE_FLAG_DOCS.python;
+    case "go":
+      return FEATURE_FLAG_DOCS.go;
+    case "php":
+      return FEATURE_FLAG_DOCS.php;
+    case "ruby":
+    case "rb":
+      return FEATURE_FLAG_DOCS.ruby;
+    case "java":
+      return FEATURE_FLAG_DOCS.java;
+    case "csharp":
+    case "cs":
+      return FEATURE_FLAG_DOCS.csharp;
+    case "swift":
+      return FEATURE_FLAG_DOCS.swift;
+    case "elixir":
+    case "ex":
+    case "exs":
+      return FEATURE_FLAG_DOCS.elixir;
+    case "kotlin":
+    case "kt":
+    case "kts":
+    case "ktm":
+      return FEATURE_FLAG_DOCS.kotlin;
+    case "flutter":
+    case "dart":
+      return FEATURE_FLAG_DOCS.flutter;
+    default:
+      return "Feature flag documentation not available for this language. Check GrowthBook docs for implementation details.";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { registerProjectTools } from "./tools/projects.js";
 import { registerSdkConnectionTools } from "./tools/sdk-connections.js";
 import { getApiKey, getApiUrl, getAppOrigin, getUser } from "./utils.js";
 import { registerSearchTool } from "./tools/search.js";
+import { registerDefaultsTools } from "./tools/defaults.js";
 
 export const baseApiUrl = getApiUrl();
 export const apiKey = getApiKey();
@@ -22,9 +23,10 @@ const server = new McpServer(
     version: "1.0.0",
   },
   {
-    instructions:
-      "You are a helpful assistant that interacts with GrowthBook, an open source feature flagging and experimentation platform. You can use tools to create and manage feature flags, experiments, and environments. Note that experiments are also called a/b tests.",
-  },
+    instructions: `You are a helpful assistant that interacts with GrowthBook, an open source feature flagging and experimentation platform. You can use tools to create and manage feature flags, experiments, and environments. Note that experiments are also called A/B tests. 
+      
+Certain tools may require you to select from a list of values. Call the resources tool to get a list of values.`,
+  }
 );
 
 registerEnvironmentTools({
@@ -58,12 +60,20 @@ registerExperimentTools({
   baseApiUrl,
   apiKey,
   appOrigin,
+  user,
 });
 
 registerSearchTool({
   server,
 });
 
+registerDefaultsTools({
+  server,
+  baseApiUrl,
+  apiKey,
+});
+
 // Start receiving messages on stdin and sending messages on stdout
 const transport = new StdioServerTransport();
+
 await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { registerFeatureTools } from "./tools/features.js";
 import { registerProjectTools } from "./tools/projects.js";
 import { registerSdkConnectionTools } from "./tools/sdk-connections.js";
 import { getApiKey, getApiUrl, getAppOrigin, getUser } from "./utils.js";
-import { registerSearchTool } from "./tools/search.js";
+import { registerSearchTools } from "./tools/search.js";
 import { registerDefaultsTools } from "./tools/defaults.js";
 
 export const baseApiUrl = getApiUrl();
@@ -63,7 +63,7 @@ registerExperimentTools({
   user,
 });
 
-registerSearchTool({
+registerSearchTools({
   server,
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,34 @@ const server = new McpServer(
     version: "1.0.0",
   },
   {
-    instructions: `You are a helpful assistant that interacts with GrowthBook, an open source feature flagging and experimentation platform. You can use tools to create and manage feature flags, experiments, and environments. Note that experiments are also called A/B tests. 
-      
-Certain tools may require you to select from a list of values. Call the resources tool to get a list of values.`,
+    instructions: `You are a helpful assistant that interacts with GrowthBook, an open source feature flagging and experimentation platform. You can create and manage feature flags, experiments (A/B tests), and other resources associated with GrowthBook.
+
+**Key Workflows:**
+
+1. **Creating Feature Flags:**
+   - Use create_feature_flag for simple boolean/string/number/json flags
+   - Use create_force_rule to add conditional rules to existing flags
+   - Always specify the correct fileExtension for code integration
+
+2. **Creating Experiments (A/B Tests):**
+   - CRITICAL: Always call get_defaults FIRST to see naming conventions and examples
+   - Use create_experiment to create experiments
+   - Experiments automatically create linked feature flags
+
+3. **Exploring Existing Resources:**
+   - Use get_projects, get_environments, get_feature_flags, get_experiments, or get_attributes to understand current setup
+   - Use get_single_feature_flag for detailed flag information
+   - Use get_stale_safe_rollouts to find completed rollouts that can be cleaned up
+
+4. **SDK Integration:**
+   - Use get_sdk_connections to see existing integrations
+   - Use create_sdk_connection for new app integrations
+   - Use generate_flag_types to create TypeScript definitions
+
+**Important Notes:**
+- Feature flags and experiments require a fileExtension parameter for proper code integration
+- Always review generated GrowthBook links with users so they can launch experiments
+- When experiments are "draft", users must visit GrowthBook to review and launch them`,
   }
 );
 

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 import envPaths from "env-paths";
 import { writeFile, readFile } from "fs/promises";

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -257,6 +257,9 @@ export async function getDefaults(
   return experimentDefaults;
 }
 
+/**
+ * Tool: get_defaults
+ */
 export async function registerDefaultsTools({
   server,
   baseApiUrl,

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -1,9 +1,9 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { handleResNotOk } from "../utils.js";
+import { z } from "zod";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 import envPaths from "env-paths";
 import { writeFile, readFile } from "fs/promises";
 import { join } from "path";
-import { z } from "zod";
 
 const paths = envPaths("growthbook-mcp"); // Use your app name
 const experimentDefaultsDir = paths.config; // This is the recommended config directory
@@ -261,11 +261,7 @@ export async function registerDefaultsTools({
   server,
   baseApiUrl,
   apiKey,
-}: {
-  server: McpServer;
-  baseApiUrl: string;
-  apiKey: string;
-}) {
+}: BaseToolsInterface) {
   server.tool(
     "get_defaults",
     "Get the default values for experiments, including hypothesis, description, datasource, assignment query, and environments.",

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -1,0 +1,280 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { handleResNotOk } from "../utils.js";
+import envPaths from "env-paths";
+import { writeFile, readFile } from "fs/promises";
+import { join } from "path";
+import { z } from "zod";
+
+const paths = envPaths("growthbook-mcp"); // Use your app name
+const experimentDefaultsDir = paths.config; // This is the recommended config directory
+const experimentDefaultsFile = join(
+  experimentDefaultsDir,
+  "experiment-defaults.json"
+);
+
+interface Experiment {
+  name: string;
+  hypothesis: string;
+  description: string;
+  settings: {
+    datasourceId: string;
+    assignmentQueryId: string;
+  };
+}
+
+interface DataSourceCount {
+  ds: string;
+  aq: string;
+  count: number;
+}
+
+interface ExperimentStatsAccumulator {
+  name: string[];
+  hypothesis: string[];
+  description: string[];
+  datasource: Record<string, DataSourceCount>;
+}
+
+export interface ExperimentDefaultsResult {
+  name: string[];
+  hypothesis: string[];
+  description: string[];
+  datasource: string;
+  assignmentQuery: string;
+  environments: string[];
+  timestamp: string;
+}
+
+export async function createDefaults(
+  apiKey: string,
+  baseApiUrl: string
+): Promise<ExperimentDefaultsResult> {
+  try {
+    const experimentsResponse = await fetch(
+      `${baseApiUrl}/api/v1/experiments`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      }
+    );
+    await handleResNotOk(experimentsResponse);
+    const experimentData = await experimentsResponse.json();
+
+    if (experimentData.experiments.length === 0) {
+      // No experiments: return assignment query and environments if possible
+      const assignmentQueryResponse = await fetch(
+        `${baseApiUrl}/api/v1/data-sources`,
+        {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        }
+      );
+      await handleResNotOk(assignmentQueryResponse);
+      const dataSourceData = await assignmentQueryResponse.json();
+
+      if (dataSourceData.dataSources.length === 0) {
+        throw new Error(
+          "No data source or assignment query found. Experiments require a data source/assignment query. Set these up in the GrowthBook and try again."
+        );
+      }
+
+      const assignmentQuery: string =
+        dataSourceData.dataSources[0].assignmentQueries[0].id;
+
+      const environmentsResponse = await fetch(
+        `${baseApiUrl}/api/v1/environments`,
+        {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        }
+      );
+      await handleResNotOk(environmentsResponse);
+      const environmentsData = await environmentsResponse.json();
+      const environments: string[] = environmentsData.environments.map(
+        ({ id }: { id: string }) => id
+      );
+
+      return {
+        name: [],
+        hypothesis: [],
+        description: [],
+        datasource: "",
+        assignmentQuery,
+        environments,
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    let experiments: Experiment[] = [];
+    if (experimentData.hasMore) {
+      const mostRecentExperiments = await fetch(
+        `${baseApiUrl}/api/v1/experiments?offset=${
+          experimentData.total -
+          Math.min(50, experimentData.count + experimentData.offset)
+        }&limit=${Math.min(50, experimentData.count + experimentData.offset)}`,
+        {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      await handleResNotOk(mostRecentExperiments);
+      const mostRecentExperimentData = await mostRecentExperiments.json();
+      experiments = mostRecentExperimentData.experiments as Experiment[];
+    } else {
+      experiments = experimentData.experiments as Experiment[];
+    }
+
+    // Aggregate experiment stats
+    const experimentStats: ExperimentStatsAccumulator =
+      experiments.reduce<ExperimentStatsAccumulator>(
+        (acc, experiment) => {
+          acc.name.push(experiment.name);
+          acc.hypothesis.push(experiment.hypothesis);
+          acc.description.push(experiment.description);
+
+          const dsKey = `${experiment.settings.datasourceId}-${experiment.settings.assignmentQueryId}`;
+          if (acc.datasource[dsKey]) {
+            acc.datasource[dsKey] = {
+              ds: experiment.settings.datasourceId,
+              aq: experiment.settings.assignmentQueryId,
+              count: acc.datasource[dsKey].count + 1,
+            };
+          } else {
+            acc.datasource[dsKey] = {
+              ds: experiment.settings.datasourceId,
+              aq: experiment.settings.assignmentQueryId,
+              count: 1,
+            };
+          }
+          return acc;
+        },
+        {
+          name: [],
+          hypothesis: [],
+          description: [],
+          datasource: {},
+        }
+      );
+
+    // Find the most frequent datasource/assignmentQuery pair
+    let mostFrequentDS: DataSourceCount = {
+      count: 0,
+      ds: "",
+      aq: "",
+    };
+    for (const value of Object.values(experimentStats.datasource)) {
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        typeof value.count === "number" &&
+        typeof value.ds === "string" &&
+        typeof value.aq === "string"
+      ) {
+        if (value.count > mostFrequentDS.count) {
+          mostFrequentDS = value;
+        }
+      }
+    }
+
+    // Fetch environments
+    const environmentsResponse = await fetch(
+      `${baseApiUrl}/api/v1/environments`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      }
+    );
+    await handleResNotOk(environmentsResponse);
+    const environmentsData = await environmentsResponse.json();
+    const environments: string[] = environmentsData.environments.map(
+      ({ id }: { id: string }) => id
+    );
+
+    return {
+      name: experimentStats.name,
+      hypothesis: experimentStats.hypothesis,
+      description: experimentStats.description,
+      datasource: mostFrequentDS.ds,
+      assignmentQuery: mostFrequentDS.aq,
+      environments,
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function getDefaults(
+  apiKey: string,
+  baseApiUrl: string
+): Promise<ExperimentDefaultsResult> {
+  let experimentDefaults;
+  try {
+    const experimentDefaultsData = await readFile(
+      experimentDefaultsFile,
+      "utf8"
+    );
+    let parsedExperimentDefaults = JSON.parse(experimentDefaultsData);
+    if (
+      !parsedExperimentDefaults ||
+      parsedExperimentDefaults.timestamp <
+        new Date().getTime() - 1000 * 60 * 60 * 24 * 30 // 30 days
+    ) {
+      const generatedExperimentDefaults = await createDefaults(
+        apiKey,
+        baseApiUrl
+      );
+      await writeFile(
+        experimentDefaultsFile,
+        JSON.stringify(generatedExperimentDefaults, null, 2)
+      );
+      parsedExperimentDefaults = generatedExperimentDefaults;
+    }
+    experimentDefaults = parsedExperimentDefaults;
+  } catch (error: any) {
+    if (error.code === "ENOENT") {
+      // experimentDefaultsFile does not exist, generate new defaults
+      const generatedExperimentDefaults = await createDefaults(
+        apiKey,
+        baseApiUrl
+      );
+      await writeFile(
+        experimentDefaultsFile,
+        JSON.stringify(generatedExperimentDefaults, null, 2)
+      );
+      experimentDefaults = generatedExperimentDefaults;
+    } else {
+      throw error;
+    }
+  }
+
+  return experimentDefaults;
+}
+
+export async function registerDefaultsTools({
+  server,
+  baseApiUrl,
+  apiKey,
+}: {
+  server: McpServer;
+  baseApiUrl: string;
+  apiKey: string;
+}) {
+  server.tool(
+    "get_defaults",
+    "Get the default values for experiments, including hypothesis, description, datasource, assignment query, and environments.",
+    {},
+    async () => {
+      const defaults = await getDefaults(apiKey, baseApiUrl);
+      return {
+        content: [{ type: "text", text: JSON.stringify(defaults, null, 2) }],
+      };
+    }
+  );
+}

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 
 interface EnvironmentTools extends BaseToolsInterface {}

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -6,7 +6,6 @@ interface EnvironmentTools extends BaseToolsInterface {}
 
 /**
  * Tool: get_environments
- * Description: Fetches all environments from the GrowthBook API. Environments can be used to enable/disable feature flags per environment and control feature delivery segmentation.
  */
 export function registerEnvironmentTools({
   server,

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -1,11 +1,8 @@
+import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { handleResNotOk } from "../utils.js";
+import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 
-interface EnvironmentTools {
-  server: McpServer;
-  baseApiUrl: string;
-  apiKey: string;
-}
+interface EnvironmentTools extends BaseToolsInterface {}
 
 /**
  * Tool: get_environments

--- a/src/tools/experiments.ts
+++ b/src/tools/experiments.ts
@@ -67,7 +67,7 @@ export function registerExperimentTools({
    */
   server.tool(
     "create_force_rule",
-    "Create a new force rule on an existing feature. If the existing feature isn't apparent, create a new feature using create_feature_flag first. A force rule sets a feature to a specific value for a specific environment based on a condition. For A/B tests and experiments, use create_experiment instead.",
+    "Create a new force rule on an existing feature. If the existing feature isn't apparent, create a new feature using create_feature_flag first. A force rule sets a feature to a specific value based on a condition. For A/B tests and experiments, use create_experiment instead.",
     {
       featureId: z
         .string()
@@ -82,7 +82,7 @@ export function registerExperimentTools({
       value: z
         .string()
         .describe("The type of the value should match the feature type"),
-      environments: z.string().array(),
+
       fileExtension: z
         .enum(SUPPORTED_FILE_EXTENSIONS)
         .describe(
@@ -94,13 +94,17 @@ export function registerExperimentTools({
       description,
       condition,
       value,
-      environments,
+
       fileExtension,
     }) => {
       try {
+        // Fetch feature defaults first and surface to user
+        const defaults = await getDefaults(apiKey, baseApiUrl);
+        const defaultEnvironments = defaults.environments;
+
         const payload = {
           // Loop through the environments and create a rule for each one keyed by environment name
-          environments: environments.reduce((acc, env) => {
+          environments: defaultEnvironments.reduce((acc, env) => {
             acc[env] = {
               enabled: true,
               rules: [

--- a/src/tools/experiments.ts
+++ b/src/tools/experiments.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   generateLinkToGrowthBook,
   getDocsMetadata,

--- a/src/tools/experiments.ts
+++ b/src/tools/experiments.ts
@@ -84,14 +84,7 @@ export function registerExperimentTools({
           "The extension of the current file. If it's unclear, ask the user."
         ),
     },
-    async ({
-      featureId,
-      description,
-      condition,
-      value,
-
-      fileExtension,
-    }) => {
+    async ({ featureId, description, condition, value, fileExtension }) => {
       try {
         // Fetch feature defaults first and surface to user
         const defaults = await getDefaults(apiKey, baseApiUrl);

--- a/src/tools/experiments.ts
+++ b/src/tools/experiments.ts
@@ -4,16 +4,12 @@ import {
   generateLinkToGrowthBook,
   getDocsMetadata,
   handleResNotOk,
+  type ExtendedToolsInterface,
+  SUPPORTED_FILE_EXTENSIONS,
 } from "../utils.js";
 import { getDefaults } from "./defaults.js";
 
-interface ExperimentTools {
-  server: McpServer;
-  baseApiUrl: string;
-  apiKey: string;
-  appOrigin: string;
-  user: string;
-}
+interface ExperimentTools extends ExtendedToolsInterface {}
 
 export function registerExperimentTools({
   server,
@@ -88,19 +84,7 @@ export function registerExperimentTools({
         .describe("The type of the value should match the feature type"),
       environments: z.string().array(),
       fileExtension: z
-        .enum([
-          ".tsx",
-          ".jsx",
-          ".ts",
-          ".js",
-          ".vue",
-          ".py",
-          ".go",
-          ".php",
-          ".rb",
-          ".java",
-          ".cs",
-        ])
+        .enum(SUPPORTED_FILE_EXTENSIONS)
         .describe(
           "The extension of the current file. If it's unclear, ask the user."
         ),
@@ -293,19 +277,7 @@ export function registerExperimentTools({
           "Experiment variations. The key should be the variation name and the value should be the variation value. Look to variations included in preview experiments for guidance on generation. The default or control variation should always be first."
         ),
       fileExtension: z
-        .enum([
-          ".tsx",
-          ".jsx",
-          ".ts",
-          ".js",
-          ".vue",
-          ".py",
-          ".go",
-          ".php",
-          ".rb",
-          ".java",
-          ".cs",
-        ])
+        .enum(SUPPORTED_FILE_EXTENSIONS)
         .describe(
           "The extension of the current file. If it's unclear, ask the user."
         ),

--- a/src/tools/features.ts
+++ b/src/tools/features.ts
@@ -1,22 +1,17 @@
 import { z } from "zod";
-
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   getDocsMetadata,
   findImplementationDocs,
   handleResNotOk,
   generateLinkToGrowthBook,
+  type ExtendedToolsInterface,
+  SUPPORTED_FILE_EXTENSIONS,
 } from "../utils.js";
 import { exec } from "child_process";
 import { promisify } from "util";
 
-interface FeatureTools {
-  server: McpServer;
-  baseApiUrl: string;
-  apiKey: string;
-  appOrigin: string;
-  user: string;
-}
+interface FeatureTools extends ExtendedToolsInterface {}
 
 export function registerFeatureTools({
   server,
@@ -66,19 +61,7 @@ export function registerFeatureTools({
         .optional()
         .describe("Tags for the feature flag"),
       fileExtension: z
-        .enum([
-          ".tsx",
-          ".jsx",
-          ".ts",
-          ".js",
-          ".vue",
-          ".py",
-          ".go",
-          ".php",
-          ".rb",
-          ".java",
-          ".cs",
-        ])
+        .enum(SUPPORTED_FILE_EXTENSIONS)
         .describe(
           "The extension of the current file. If it's unclear, ask the user."
         ),

--- a/src/tools/features.ts
+++ b/src/tools/features.ts
@@ -128,8 +128,7 @@ export function registerFeatureTools({
         }
 
         const data = await res.json();
-        const docsText = await findImplementationDocs(fileExtension);
-        const { docs, language } = getDocsMetadata(fileExtension);
+        const { docs, language, stub } = getDocsMetadata(fileExtension);
         const linkToGrowthBook = generateLinkToGrowthBook(
           appOrigin,
           "features",
@@ -145,7 +144,7 @@ export function registerFeatureTools({
         **How to use it in your code:**
         (To the LLM agent. Use the text below to properly add the feature flag to the codebase. Also, surface the relevant docs/implemenation to the user)
 
-        ${docsText}
+        ${stub}
 
         **Want to learn more?**
         See the [GrowthBook ${language} docs](${docs})
@@ -171,16 +170,16 @@ export function registerFeatureTools({
     {
       limit: z.number().optional().default(100),
       offset: z.number().optional().default(0),
-      project: z.string().optional(),
+      projectId: z.string().optional(),
     },
-    async ({ limit, offset, project }) => {
+    async ({ limit, offset, projectId }) => {
       try {
         const queryParams = new URLSearchParams({
           limit: limit?.toString(),
           offset: offset?.toString(),
         });
 
-        if (project) queryParams.append("project", project);
+        if (projectId) queryParams.append("projectId", projectId);
 
         const res = await fetch(
           `${baseApiUrl}/api/v1/features?${queryParams.toString()}`,

--- a/src/tools/features.ts
+++ b/src/tools/features.ts
@@ -6,7 +6,6 @@ import {
   type ExtendedToolsInterface,
   SUPPORTED_FILE_EXTENSIONS,
 } from "../utils.js";
-import { getDefaults } from "./defaults.js";
 import { exec } from "child_process";
 
 interface FeatureTools extends ExtendedToolsInterface {}

--- a/src/tools/features.ts
+++ b/src/tools/features.ts
@@ -19,7 +19,6 @@ export function registerFeatureTools({
 }: FeatureTools) {
   /**
    * Tool: create_feature_flag
-   * Description: Creates, adds, or wraps an element with a feature flag in GrowthBook. Allows specifying key, type, default value, and other metadata.
    */
   server.tool(
     "create_feature_flag",
@@ -98,19 +97,17 @@ export function registerFeatureTools({
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        console.error("Error creating feature flag:", error);
-        throw error;
+        throw new Error(`Error creating feature flag: ${error}`);
       }
     }
   );
 
   /**
    * Tool: get_feature_flags
-   * Description: Fetches all feature flags from the GrowthBook API, with optional limit, offset, and project filtering.
    */
   server.tool(
     "get_feature_flags",
-    "Fetches all feature flags from the GrowthBook API. Flags are returned in the order they were created, from oldest to newest.",
+    "Fetches all feature flags from the GrowthBook API, with optional limit, offset, and project filtering.",
     {
       limit: z.number().optional().default(100),
       offset: z.number().optional().default(0),
@@ -140,15 +137,13 @@ export function registerFeatureTools({
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
         };
       } catch (error) {
-        console.error("Error fetching flags:", error);
-        throw error;
+        throw new Error(`Error fetching flags: ${error}`);
       }
     }
   );
 
   /**
    * Tool: get_single_feature_flag
-   * Description: Fetches a specific feature flag from the GrowthBook API by its ID, with optional project filtering.
    */
   server.tool(
     "get_single_feature_flag",
@@ -195,15 +190,13 @@ export function registerFeatureTools({
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        console.error("Error fetching flags:", error);
-        throw error;
+        throw new Error(`Error fetching flags: ${error}`);
       }
     }
   );
 
   /**
    * Tool: get_stale_safe_rollouts
-   * Description: Fetches all complete safe rollouts (rolled-back or released) from the GrowthBook API, with optional limit, offset, and project filtering.
    */
   server.tool(
     "get_stale_safe_rollouts",
@@ -211,16 +204,13 @@ export function registerFeatureTools({
     {
       limit: z.number().optional().default(100),
       offset: z.number().optional().default(0),
-      project: z.string().optional(),
     },
-    async ({ limit, offset, project }) => {
+    async ({ limit, offset }) => {
       try {
         const queryParams = new URLSearchParams({
           limit: limit?.toString(),
           offset: offset?.toString(),
         });
-
-        if (project) queryParams.append("project", project);
 
         const res = await fetch(
           `${baseApiUrl}/api/v1/features?${queryParams.toString()}`,
@@ -265,15 +255,13 @@ export function registerFeatureTools({
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        console.error("Error fetching stale safe rollouts:", error);
-        throw error;
+        throw new Error(`Error fetching stale safe rollouts: ${error}`);
       }
     }
   );
 
   /**
    * Tool: generate_flag_types
-   * Description: Generates types for feature flags using the GrowthBook CLI.
    */
   server.tool(
     "generate_flag_types",

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -6,7 +6,6 @@ interface ProjectTools extends BaseToolsInterface {}
 
 /**
  * Tool: get_projects
- * Description: Fetches all projects from the GrowthBook API, with optional limit and offset for pagination.
  */
 export function registerProjectTools({
   server,
@@ -17,7 +16,7 @@ export function registerProjectTools({
     "get_projects",
     "Fetches all projects from the GrowthBook API",
     {
-      limit: z.number().optional().default(10),
+      limit: z.number().optional().default(100),
       offset: z.number().optional().default(0),
     },
     async ({ limit, offset }) => {

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 
 interface ProjectTools extends BaseToolsInterface {}

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -1,12 +1,8 @@
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { handleResNotOk } from "../utils.js";
+import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 
-interface ProjectTools {
-  server: McpServer;
-  baseApiUrl: string;
-  apiKey: string;
-}
+interface ProjectTools extends BaseToolsInterface {}
 
 /**
  * Tool: get_projects

--- a/src/tools/sdk-connections.ts
+++ b/src/tools/sdk-connections.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 
 interface SdkConnectionTools extends BaseToolsInterface {}

--- a/src/tools/sdk-connections.ts
+++ b/src/tools/sdk-connections.ts
@@ -10,8 +10,6 @@ export function registerSdkConnectionTools({
 }: SdkConnectionTools) {
   /**
    * Tool: get_sdk_connections
-   * Description: Retrieves all SDK connections, which are how GrowthBook connects to an app.
-   * Users need the key, which is a public key that allows the app to fetch features and experiments from the API.
    */
   server.tool(
     "get_sdk_connections",
@@ -45,17 +43,13 @@ export function registerSdkConnectionTools({
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${error}` }],
-        };
+        throw new Error(`Error fetching sdk connections: ${error}`);
       }
     }
   );
 
   /**
    * Tool: create_sdk_connection
-   * Description: Creates an SDK connection for a user. Returns an SDK clientKey that can be used to fetch features and experiments.
-   * Requires a name, language, and optionally an environment.
    */
   server.tool(
     "create_sdk_connection",
@@ -150,9 +144,7 @@ export function registerSdkConnectionTools({
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${error}` }],
-        };
+        throw new Error(`Error creating sdk connection: ${error}`);
       }
     }
   );

--- a/src/tools/sdk-connections.ts
+++ b/src/tools/sdk-connections.ts
@@ -25,15 +25,15 @@ export function registerSdkConnectionTools({
     {
       limit: z.number().optional().default(100),
       offset: z.number().optional().default(0),
-      project: z.string().optional(),
+      projectId: z.string().optional(),
     },
-    async ({ limit, offset, project }) => {
+    async ({ limit, offset, projectId }) => {
       try {
         const queryParams = new URLSearchParams({
           limit: limit?.toString(),
           offset: offset?.toString(),
         });
-        if (project) queryParams.append("project", project);
+        if (projectId) queryParams.append("projectId", projectId);
 
         const res = await fetch(
           `${baseApiUrl}/api/v1/sdk-connections?${queryParams.toString()}`,

--- a/src/tools/sdk-connections.ts
+++ b/src/tools/sdk-connections.ts
@@ -1,12 +1,8 @@
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { handleResNotOk } from "../utils.js";
+import { handleResNotOk, type BaseToolsInterface } from "../utils.js";
 
-interface SdkConnectionTools {
-  server: McpServer;
-  baseApiUrl: string;
-  apiKey: string;
-}
+interface SdkConnectionTools extends BaseToolsInterface {}
 export function registerSdkConnectionTools({
   server,
   baseApiUrl,
@@ -19,9 +15,7 @@ export function registerSdkConnectionTools({
    */
   server.tool(
     "get_sdk_connections",
-    `Get all SDK connections, 
-    which are how GrowthBook connects to an app. 
-    Importantly, users need the key, which is a public client key that allows the app to fetch features and experiments the API `,
+    "Get all SDK connections. SDK connections are how GrowthBook connects to an app. Users need the client key to fetch features and experiments from the API.",
     {
       limit: z.number().optional().default(100),
       offset: z.number().optional().default(0),

--- a/src/tools/sdk-connections.ts
+++ b/src/tools/sdk-connections.ts
@@ -19,15 +19,13 @@ export function registerSdkConnectionTools({
     {
       limit: z.number().optional().default(100),
       offset: z.number().optional().default(0),
-      projectId: z.string().optional(),
     },
-    async ({ limit, offset, projectId }) => {
+    async ({ limit, offset }) => {
       try {
         const queryParams = new URLSearchParams({
           limit: limit?.toString(),
           offset: offset?.toString(),
         });
-        if (projectId) queryParams.append("projectId", projectId);
 
         const res = await fetch(
           `${baseApiUrl}/api/v1/sdk-connections?${queryParams.toString()}`,

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,12 +1,16 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { searchGrowthBookDocs } from "../utils.js";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { searchGrowthBookDocs, type BaseToolsInterface } from "../utils.js";
+
+interface SearchTools {
+  server: McpServer;
+}
 
 /**
  * Tool: search_growthbook_docs
  * Description: Searches the GrowthBook documentation for information on how to use a feature, based on a user-provided query.
  */
-export function registerSearchTool({ server }: { server: McpServer }) {
+export function registerSearchTools({ server }: SearchTools) {
   server.tool(
     "search_growthbook_docs",
     "Search the GrowthBook docs on how to use a feature",

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -8,7 +8,6 @@ interface SearchTools {
 
 /**
  * Tool: search_growthbook_docs
- * Description: Searches the GrowthBook documentation for information on how to use a feature, based on a user-provided query.
  */
 export function registerSearchTools({ server }: SearchTools) {
   server.tool(

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,15 +1,11 @@
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { searchGrowthBookDocs, type BaseToolsInterface } from "../utils.js";
-
-interface SearchTools {
-  server: McpServer;
-}
+import { searchGrowthBookDocs } from "../utils.js";
 
 /**
  * Tool: search_growthbook_docs
  */
-export function registerSearchTools({ server }: SearchTools) {
+export function registerSearchTools({ server }: { server: McpServer }) {
   server.tool(
     "search_growthbook_docs",
     "Search the GrowthBook docs on how to use a feature",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,41 @@
 import { getFeatureFlagDocs } from "./docs.js";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// Shared interfaces for MCP tools
+export interface BaseToolsInterface {
+  server: McpServer;
+  baseApiUrl: string;
+  apiKey: string;
+}
+
+export interface ExtendedToolsInterface extends BaseToolsInterface {
+  appOrigin: string;
+  user: string;
+}
+
+// Shared file extension enum for all MCP tools
+export const SUPPORTED_FILE_EXTENSIONS = [
+  ".tsx",
+  ".jsx", 
+  ".ts",
+  ".js",
+  ".vue",
+  ".py",
+  ".go",
+  ".php",
+  ".rb",
+  ".java",
+  ".cs",
+  ".swift",
+  ".ex",
+  ".exs",
+  ".kt",
+  ".kts",
+  ".ktm",
+  ".dart",
+] as const;
+
+export type SupportedFileExtension = (typeof SUPPORTED_FILE_EXTENSIONS)[number];
 
 export async function handleResNotOk(res: Response) {
   if (!res.ok) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,13 @@
+import { getFeatureFlagDocs } from "./docs.js";
+
 export async function handleResNotOk(res: Response) {
   if (!res.ok) {
+    const errorText = await res.text();
     let errorMessage = `HTTP ${res.status} ${res.statusText}`;
     try {
-      const errorBody = await res.json();
+      const errorBody = JSON.parse(errorText);
       errorMessage += `: ${JSON.stringify(errorBody)}`;
     } catch {
-      // fallback to text if not JSON
-      const errorText = await res.text();
       if (errorText) errorMessage += `: ${errorText}`;
     }
     throw new Error(errorMessage);
@@ -47,69 +48,69 @@ export function getDocsMetadata(extension: string) {
     case ".jsx":
       return {
         language: "react",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/react.mdx",
+        stub: getFeatureFlagDocs("react"),
         docs: "https://docs.growthbook.io/lib/react",
       };
     case ".ts":
     case ".js":
       return {
         language: "javascript",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/js.mdx",
+        stub: getFeatureFlagDocs("javascript"),
         docs: "https://docs.growthbook.io/lib/js",
       };
     case ".vue":
       return {
         language: "vue",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/vue.mdx",
+        stub: getFeatureFlagDocs("vue"),
         docs: "https://docs.growthbook.io/lib/vue",
       };
     case ".py":
       return {
         language: "python",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/python.mdx",
+        stub: getFeatureFlagDocs("python"),
         docs: "https://docs.growthbook.io/lib/python",
       };
     case ".go":
       return {
         language: "go",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/go.mdx",
+        stub: getFeatureFlagDocs("go"),
         docs: "https://docs.growthbook.io/lib/go",
       };
     case ".php":
       return {
         language: "php",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/php.mdx",
+        stub: getFeatureFlagDocs("php"),
         docs: "https://docs.growthbook.io/lib/php",
       };
     case ".rb":
       return {
         language: "ruby",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/ruby.mdx",
+        stub: getFeatureFlagDocs("ruby"),
         docs: "https://docs.growthbook.io/lib/ruby",
       };
     case ".java":
       return {
         language: "java",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/java.mdx",
+        stub: getFeatureFlagDocs("java"),
         docs: "https://docs.growthbook.io/lib/java",
       };
     case ".cs":
       return {
         language: "csharp",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/csharp.mdx",
+        stub: getFeatureFlagDocs("csharp"),
         docs: "https://docs.growthbook.io/lib/csharp",
       };
     case ".swift":
       return {
         language: "swift",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/swift.mdx",
+        stub: getFeatureFlagDocs("swift"),
         docs: "https://docs.growthbook.io/lib/swift",
       };
     case ".ex":
     case ".exs":
       return {
         language: "elixir",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/elixir.mdx",
+        stub: getFeatureFlagDocs("elixir"),
         docs: "https://docs.growthbook.io/lib/elixir",
       };
     case ".kt":
@@ -117,19 +118,19 @@ export function getDocsMetadata(extension: string) {
     case ".ktm":
       return {
         language: "kotlin",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/kotlin.mdx",
+        stub: getFeatureFlagDocs("kotlin"),
         docs: "https://docs.growthbook.io/lib/kotlin",
       };
     case ".dart":
       return {
         language: "flutter",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/flutter.mdx",
+        stub: getFeatureFlagDocs("flutter"),
         docs: "https://docs.growthbook.io/lib/flutter",
       };
     default:
       return {
         language: "unknown",
-        md: "https://raw.githubusercontent.com/growthbook/growthbook/main/docs/docs/lib/index.mdx",
+        stub: getFeatureFlagDocs("unknown"),
         docs: "https://docs.growthbook.io/lib/",
       };
   }
@@ -159,18 +160,6 @@ export async function searchGrowthBookDocs(query: string) {
     return hits;
   } catch (error) {
     return [];
-  }
-}
-
-export async function findImplementationDocs(extension: string) {
-  const { md } = getDocsMetadata(extension);
-  try {
-    const response = await fetch(md);
-    await handleResNotOk(response);
-    const markdown = await response.text();
-    return markdown;
-  } catch (error) {
-    return "Docs not found";
   }
 }
 


### PR DESCRIPTION
The major update here is to add `create_experiment` as an MCP tool.

Additionally:
- Bug fixes
- More consistency on tool responses and error states
- Improved flag generation
- Simplified tool params