### PR TITLE
Add Project Filtering to Feature Flags

### DIFF
--- a/src/tools/features.ts
+++ b/src/tools/features.ts
@@ -142,13 +142,16 @@ export function registerFeatureTools({
     "Fetches all feature flags from the GrowthBook API, with optional limit, offset, and project filtering.",
     {
       ...paginationSchema,
+      projectId: z.string().optional().describe("The project ID to filter by"),
     },
-    async ({ limit, offset }) => {
+    async ({ limit, offset, projectId }) => {
       try {
         const queryParams = new URLSearchParams({
           limit: limit?.toString(),
           offset: offset?.toString(),
         });
+
+        if (projectId) queryParams.append("projectId", projectId);
 
         const res = await fetch(
           `${baseApiUrl}/api/v1/features?${queryParams.toString()}`,


### PR DESCRIPTION
**What's this about?**
This PR adds the ability to filter feature flags by project when fetching them from the GrowthBook API.

**What changed?**

- Added an optional projectId parameter to the get_feature_flags tool
- When you pass a project ID, it gets sent along to the GrowthBook API to filter the results
- If you don't pass it, everything works like before - no breaking changes!
