### PR TITLE
Add Metric Exploration tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `create_metric_exploration` tool — chart metric data over time with configurable date ranges and chart types, returns visualization data and a link to view in GrowthBook
+
 ## [1.8.1] - 2026-03-09
 
 Re-publish of 1.8.0 to include `list_feature_keys` tool in npm package.

--- a/manifest.json
+++ b/manifest.json
@@ -99,6 +99,10 @@
     {
       "name": "search_growthbook_docs",
       "description": "Search official GrowthBook documentation for SDK integration, metrics setup, and experimentation best practices."
+    },
+    {
+      "name": "create_metric_exploration",
+      "description": "Chart an existing GrowthBook metric over time. Returns chart data and a link to view the visualization."
     }
   ],
   "prompts": [

--- a/manifest.json
+++ b/manifest.json
@@ -102,7 +102,7 @@
     },
     {
       "name": "create_metric_exploration",
-      "description": "Chart an existing GrowthBook metric over time. Returns chart data and a link to view the visualization."
+      "description": "Chart an existing GrowthBook fact metric (IDs starting with 'fact__') over time. Returns chart data and a link to view the visualization."
     }
   ],
   "prompts": [

--- a/manifest.json
+++ b/manifest.json
@@ -102,7 +102,7 @@
     },
     {
       "name": "create_metric_exploration",
-      "description": "Chart an existing GrowthBook fact metric (IDs starting with 'fact__') over time. Returns chart data and a link to view the visualization."
+      "description": "Chart an existing GrowthBook fact metric (IDs starting with 'fact__') over time. Legacy/standard metrics (IDs starting with 'met_') are not supported. Returns chart data and a link to view the visualization. If the query is still running, retry after 10-15 seconds."
     }
   ],
   "prompts": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -993,7 +993,6 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1561,7 +1560,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1809,7 +1807,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2200,7 +2197,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2696,7 +2692,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2772,7 +2767,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -2888,7 +2882,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/api-type-helpers.ts
+++ b/src/api-type-helpers.ts
@@ -90,3 +90,11 @@ export type ListDataSourcesResponse =
 
 // Component schema aliases (for formatters that work with single entities or arrays)
 export type Feature = Components["schemas"]["Feature"];
+
+// Product Analytics Explorations
+export type CreateExplorationResponse =
+  Paths["/product-analytics/metric-exploration"]["post"]["responses"][200]["content"]["application/json"];
+export type CreateFactTableExplorationResponse =
+  Paths["/product-analytics/fact-table-exploration"]["post"]["responses"][200]["content"]["application/json"];
+export type CreateDataSourceExplorationResponse =
+  Paths["/product-analytics/data-source-exploration"]["post"]["responses"][200]["content"]["application/json"];

--- a/src/api-types.d.ts
+++ b/src/api-types.d.ts
@@ -36,9 +36,19 @@ export interface paths {
         /** Get a single feature */
         get: operations["getFeature"];
         put?: never;
-        /** Partially update a feature */
+        /**
+         * Partially update a feature
+         * @description Updates any combination of a feature's metadata (description, owner, tags, project), default value, environment settings (rules, kill switches, enabled state), prerequisites, holdout assignment, or JSON schema validation. All provided fields are merged into the existing feature and the result is immediately published as a new revision.
+         *
+         *     Returns 403 if the API key lacks permission or if approval rules are enabled for an affected environment and the org setting "REST API always bypasses approval requirements" is off.
+         */
         post: operations["updateFeature"];
-        /** Deletes a single feature */
+        /**
+         * Deletes a single feature
+         * @description Permanently deletes a feature and all of its revisions.
+         *
+         *     Archived features can be deleted freely. Deleting a live (non-archived) feature returns 403 unless the org setting "REST API always bypasses approval requirements" is enabled, or the API key lacks delete permission.
+         */
         delete: operations["deleteFeature"];
         options?: never;
         head?: never;
@@ -57,7 +67,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Toggle a feature in one or more environments */
+        /**
+         * Toggle a feature in one or more environments
+         * @description Enables or disables a feature in one or more environments simultaneously. Accepts a map of environment name → boolean and immediately publishes the change.
+         *
+         *     Returns 403 if the API key lacks permission or if approval rules are enabled for an affected environment and the org setting "REST API always bypasses approval requirements" is off.
+         */
         post: operations["toggleFeature"];
         delete?: never;
         options?: never;
@@ -77,7 +92,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Revert a feature to a specific revision */
+        /**
+         * Revert a feature to a specific revision
+         * @description Creates a new revision whose rules and values match a previously-published revision, then immediately publishes it. This leaves a clear audit trail of the revert action in the revision history.
+         *
+         *     Returns 403 if the API key lacks permission or if approval rules are enabled for an affected environment and the org setting "REST API always bypasses approval requirements" is off.
+         */
         post: operations["revertFeature"];
         delete?: never;
         options?: never;
@@ -406,6 +426,45 @@ export interface paths {
         /** Create Experiment Snapshot */
         post: operations["postExperimentSnapshot"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/experiments/{id}/variation/{variationId}/screenshot/upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The id of the requested resource */
+                id: components["parameters"]["id"];
+                /** @description The variation ID (e.g. var_abc123) from the experiment's variations */
+                variationId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upload a variation screenshot */
+        post: operations["postVariationImageUpload"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/experiments/{id}/variation/{variationId}/screenshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a variation screenshot */
+        delete: operations["deleteVariationScreenshot"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1038,6 +1097,94 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/product-analytics/metric-exploration": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a Metric based visualization */
+        post: operations["postMetricExploration"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/product-analytics/fact-table-exploration": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run a Fact Table based visualization */
+        post: operations["postFactTableExploration"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/product-analytics/data-source-exploration": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a Data Source based visualization */
+        post: operations["postDataSourceExploration"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all custom fields */
+        get: operations["listCustomFields"];
+        put?: never;
+        /** Create a single customField */
+        post: operations["createCustomField"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/custom-fields/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single customField */
+        get: operations["getCustomField"];
+        /** Update a single customField */
+        put: operations["updateCustomField"];
+        post?: never;
+        /** Delete a single customField */
+        delete: operations["deleteCustomField"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dashboards/{id}": {
         parameters: {
             query?: never;
@@ -1092,38 +1239,18 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/custom-fields": {
+    "/experiment-templates": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get all custom fields */
-        get: operations["listCustomFields"];
+        /** Get all experimentTemplates */
+        get: operations["listExperimentTemplates"];
         put?: never;
-        /** Create a single customField */
-        post: operations["createCustomField"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/custom-fields/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a single customField */
-        get: operations["getCustomField"];
-        /** Update a single customField */
-        put: operations["updateCustomField"];
         post?: never;
-        /** Delete a single customField */
-        delete: operations["deleteCustomField"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -1241,6 +1368,246 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        AnalyticsExploration: {
+            id: string;
+            /** Format: date-time */
+            dateCreated: string;
+            /** Format: date-time */
+            dateUpdated: string;
+            datasource: string;
+            /** @enum {string} */
+            status: "running" | "success" | "error";
+            dateStart: string;
+            dateEnd: string;
+            error?: string | null;
+            result: {
+                rows: {
+                    dimensions: (string | null)[];
+                    values: {
+                        metricId: string;
+                        numerator: number | null;
+                        denominator: number | null;
+                    }[];
+                }[];
+            };
+            config: {
+                /** @description ID of the datasource to query */
+                datasource: string;
+                dimensions: ({
+                    /** @constant */
+                    dimensionType: "date";
+                    column: string | null;
+                    /** @enum {string} */
+                    dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                } | {
+                    /** @constant */
+                    dimensionType: "dynamic";
+                    column: string | null;
+                    maxValues: number;
+                } | {
+                    /** @constant */
+                    dimensionType: "static";
+                    column: string;
+                    values: string[];
+                } | {
+                    /** @constant */
+                    dimensionType: "slice";
+                    slices: {
+                        name: string;
+                        filters: {
+                            /** @enum {string} */
+                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                            column?: string;
+                            values?: string[];
+                        }[];
+                    }[];
+                })[];
+                /** @enum {string} */
+                chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                dateRange: {
+                    /** @enum {string} */
+                    predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                    lookbackValue: number | null;
+                    lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                    startDate: string | null;
+                    endDate: string | null;
+                };
+                /** @constant */
+                type: "metric";
+                dataset: {
+                    /** @constant */
+                    type: "metric";
+                    values: {
+                        name: string;
+                        rowFilters: {
+                            /** @enum {string} */
+                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                            column?: string;
+                            values?: string[];
+                        }[];
+                        /** @constant */
+                        type: "metric";
+                        metricId: string;
+                        unit: string | null;
+                        denominatorUnit: string | null;
+                    }[];
+                };
+            } | {
+                /** @description ID of the datasource to query */
+                datasource: string;
+                dimensions: ({
+                    /** @constant */
+                    dimensionType: "date";
+                    column: string | null;
+                    /** @enum {string} */
+                    dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                } | {
+                    /** @constant */
+                    dimensionType: "dynamic";
+                    column: string | null;
+                    maxValues: number;
+                } | {
+                    /** @constant */
+                    dimensionType: "static";
+                    column: string;
+                    values: string[];
+                } | {
+                    /** @constant */
+                    dimensionType: "slice";
+                    slices: {
+                        name: string;
+                        filters: {
+                            /** @enum {string} */
+                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                            column?: string;
+                            values?: string[];
+                        }[];
+                    }[];
+                })[];
+                /** @enum {string} */
+                chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                dateRange: {
+                    /** @enum {string} */
+                    predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                    lookbackValue: number | null;
+                    lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                    startDate: string | null;
+                    endDate: string | null;
+                };
+                /** @constant */
+                type: "fact_table";
+                dataset: {
+                    /** @constant */
+                    type: "fact_table";
+                    factTableId: string | null;
+                    values: {
+                        name: string;
+                        rowFilters: {
+                            /** @enum {string} */
+                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                            column?: string;
+                            values?: string[];
+                        }[];
+                        /** @constant */
+                        type: "fact_table";
+                        /** @enum {string} */
+                        valueType: "unit_count" | "count" | "sum";
+                        valueColumn: string | null;
+                        unit: string | null;
+                    }[];
+                };
+            } | {
+                /** @description ID of the datasource to query */
+                datasource: string;
+                dimensions: ({
+                    /** @constant */
+                    dimensionType: "date";
+                    column: string | null;
+                    /** @enum {string} */
+                    dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                } | {
+                    /** @constant */
+                    dimensionType: "dynamic";
+                    column: string | null;
+                    maxValues: number;
+                } | {
+                    /** @constant */
+                    dimensionType: "static";
+                    column: string;
+                    values: string[];
+                } | {
+                    /** @constant */
+                    dimensionType: "slice";
+                    slices: {
+                        name: string;
+                        filters: {
+                            /** @enum {string} */
+                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                            column?: string;
+                            values?: string[];
+                        }[];
+                    }[];
+                })[];
+                /** @enum {string} */
+                chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                dateRange: {
+                    /** @enum {string} */
+                    predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                    lookbackValue: number | null;
+                    lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                    startDate: string | null;
+                    endDate: string | null;
+                };
+                /** @constant */
+                type: "data_source";
+                dataset: {
+                    /** @constant */
+                    type: "data_source";
+                    table: string;
+                    path: string;
+                    timestampColumn: string;
+                    columnTypes: {
+                        [key: string]: "string" | "number" | "date" | "boolean" | "other";
+                    };
+                    values: {
+                        name: string;
+                        rowFilters: {
+                            /** @enum {string} */
+                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                            column?: string;
+                            values?: string[];
+                        }[];
+                        /** @constant */
+                        type: "data_source";
+                        /** @enum {string} */
+                        valueType: "unit_count" | "count" | "sum";
+                        valueColumn: string | null;
+                        unit: string | null;
+                    }[];
+                };
+            };
+        };
+        CustomField: {
+            id: string;
+            /** Format: date-time */
+            dateCreated: string;
+            /** Format: date-time */
+            dateUpdated: string;
+            name: string;
+            description?: string;
+            placeholder?: string;
+            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+            /** @enum {string} */
+            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
+            values?: string;
+            required: boolean;
+            index?: boolean;
+            creator?: string;
+            projects?: string[];
+            /** @enum {string} */
+            section: "feature" | "experiment";
+            active?: boolean;
+        };
         Dashboard: {
             id: string;
             uid: string;
@@ -1418,6 +1785,7 @@ export interface components {
                 snapshotId?: string;
                 explorerAnalysisId: string;
                 config: {
+                    /** @description ID of the datasource to query */
                     datasource: string;
                     dimensions: ({
                         /** @constant */
@@ -1490,6 +1858,7 @@ export interface components {
                 snapshotId?: string;
                 explorerAnalysisId: string;
                 config: {
+                    /** @description ID of the datasource to query */
                     datasource: string;
                     dimensions: ({
                         /** @constant */
@@ -1564,6 +1933,7 @@ export interface components {
                 snapshotId?: string;
                 explorerAnalysisId: string;
                 config: {
+                    /** @description ID of the datasource to query */
                     datasource: string;
                     dimensions: ({
                         /** @constant */
@@ -1634,26 +2004,58 @@ export interface components {
                 };
             })[];
         };
-        CustomField: {
+        ExperimentTemplate: {
             id: string;
             /** Format: date-time */
             dateCreated: string;
             /** Format: date-time */
             dateUpdated: string;
-            name: string;
+            project?: string;
+            owner: string;
+            templateMetadata: {
+                name: string;
+                description?: string;
+            };
+            /** @enum {string} */
+            type: "standard";
+            hypothesis?: string;
             description?: string;
-            placeholder?: string;
-            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+            tags?: string[];
+            customFields?: {
+                [key: string]: string;
+            };
+            datasource: string;
+            exposureQueryId: string;
+            hashAttribute?: string;
+            fallbackAttribute?: string;
+            disableStickyBucketing?: boolean;
+            goalMetrics?: string[];
+            secondaryMetrics?: string[];
+            guardrailMetrics?: string[];
+            activationMetric?: string;
             /** @enum {string} */
-            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
-            values?: string;
-            required: boolean;
-            index?: boolean;
-            creator?: string;
-            projects?: string[];
-            /** @enum {string} */
-            section: "feature" | "experiment";
-            active?: boolean;
+            statsEngine: "bayesian" | "frequentist";
+            segment?: string;
+            skipPartialData?: boolean;
+            targeting: {
+                coverage: number;
+                savedGroups?: {
+                    /** @enum {string} */
+                    match: "all" | "none" | "any";
+                    ids: string[];
+                }[];
+                prerequisites?: {
+                    id: string;
+                    condition: string;
+                }[];
+                condition: string;
+            };
+            customMetricSlices?: {
+                slices: {
+                    column: string;
+                    levels: string[];
+                }[];
+            }[];
         };
         MetricGroup: {
             id: string;
@@ -1933,6 +2335,12 @@ export interface components {
             customFields?: {
                 [key: string]: unknown;
             };
+            holdout?: {
+                /** @description Holdout ID */
+                id: string;
+                /** @description The feature value assigned to users in the holdout treatment group */
+                value: string;
+            } | null;
         };
         FeatureWithRevisions: components["schemas"]["Feature"] & {
             revisions?: components["schemas"]["FeatureRevision"][];
@@ -2139,11 +2547,54 @@ export interface components {
             status: string;
             createdBy?: string;
             publishedBy?: string;
+            /** @description The default value at the time this revision was created */
+            defaultValue?: string;
             rules: {
                 [key: string]: components["schemas"]["FeatureRule"][];
             };
             definitions?: {
                 [key: string]: string;
+            };
+            /** @description Per-environment enabled state captured in this revision (only present when kill-switch gating is enabled) */
+            environmentsEnabled?: {
+                [key: string]: boolean;
+            };
+            /** @description Per-environment prerequisites captured in this revision (only present when prerequisite gating is enabled) */
+            envPrerequisites?: {
+                [key: string]: {
+                    /** @description Feature ID */
+                    id: string;
+                    condition: string;
+                }[];
+            };
+            /** @description Feature-level prerequisites captured in this revision (only present when prerequisite gating is enabled) */
+            prerequisites?: {
+                /** @description Feature ID */
+                id: string;
+                condition: string;
+            }[];
+            /** @description Metadata fields captured in this revision (only present when metadata gating is enabled) */
+            metadata?: {
+                description?: string;
+                owner?: string;
+                project?: string;
+                tags?: string[];
+                neverStale?: boolean;
+                valueType?: string;
+                jsonSchema?: {
+                    /** @enum {string} */
+                    schemaType?: "schema" | "simple";
+                    schema?: string;
+                    simple?: {
+                        [key: string]: unknown;
+                    };
+                    /** Format: date-time */
+                    date?: string;
+                    enabled?: boolean;
+                };
+                customFields?: {
+                    [key: string]: unknown;
+                };
             };
         };
         SdkConnection: {
@@ -2267,6 +2718,7 @@ export interface components {
                     levels: string[];
                 }[];
             }[];
+            templateId?: string;
         };
         ExperimentSnapshot: {
             id: string;
@@ -2823,12 +3275,17 @@ export interface components {
             loseRisk: number;
             secureAttributeSalt: string;
             killswitchConfirmation: boolean;
+            /** @enum {string} */
+            featureKillSwitchBehavior?: "off" | "warn";
             requireReviews: {
                 requireReviewOn?: boolean;
                 resetReviewOnChange?: boolean;
                 environments?: string[];
                 projects?: string[];
+                featureRequireEnvironmentReview?: boolean;
+                featureRequireMetadataReview?: boolean;
             }[];
+            restApiBypassesReviews?: boolean;
             featureKeyExample: string;
             featureRegexValidator: string;
             banditScheduleValue: number;
@@ -3230,6 +3687,13 @@ export interface operations {
                     customFields?: {
                         [key: string]: string;
                     };
+                    /** @description Holdout to assign this feature to. Pass `null` to remove the feature from its current holdout. Omit the field entirely to leave the holdout unchanged. */
+                    holdout?: {
+                        /** @description Holdout ID */
+                        id: string;
+                        /** @description The feature value assigned to users in the holdout treatment group */
+                        value: string;
+                    } | null;
                 };
             };
         };
@@ -4234,10 +4698,10 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
-                    /** @description ID for the [DataSource](#tag/DataSource_model) */
+                    /** @description ID for the [DataSource](#tag/DataSource_model). Can only be set if a templateId is not provided. */
                     datasourceId?: string;
-                    /** @description The ID property of one of the assignment query objects associated with the datasource */
-                    assignmentQueryId: string;
+                    /** @description The ID property of one of the assignment query objects associated with the datasource. Can only be set if a templateId is not provided. */
+                    assignmentQueryId?: string;
                     trackingKey: string;
                     /** @description If true, allow creating an experiment even if another experiment with the same tracking key already exists */
                     bypassDuplicateKeyCheck?: boolean;
@@ -4247,6 +4711,8 @@ export interface operations {
                     type?: "standard" | "multi-armed-bandit";
                     /** @description Project ID which the experiment belongs to */
                     project?: string;
+                    /** @description ID of the [ExperimentTemplate](#tag/ExperimentTemplate_model) this experiment was created from. Template fields are applied by default and overridden by explicitly provided payload fields. */
+                    templateId?: string;
                     /** @description Hypothesis of the experiment */
                     hypothesis?: string;
                     /** @description Description of the experiment */
@@ -4476,7 +4942,18 @@ export interface operations {
                     disableStickyBucketing?: boolean;
                     bucketVersion?: number;
                     minBucketVersion?: number;
+                    /**
+                     * @description The result status of the experiment. Maps to resultSummary.status in the GET response.
+                     * @enum {string}
+                     */
+                    results?: "dnf" | "won" | "lost" | "inconclusive";
+                    /** @description The index of the winning variation (0-indexed). Maps to resultSummary.winner (variation ID) in the GET response. */
+                    winner?: number;
+                    /** @description Analysis summary or conclusions for the experiment. Maps to resultSummary.conclusions in the GET response. */
+                    analysis?: string;
+                    /** @description The ID of the released variation. Maps to resultSummary.releasedVariationId in the GET response. */
                     releasedVariationId?: string;
+                    /** @description If true, the experiment is excluded from the SDK payload. Maps to resultSummary.excludeFromPayload in the GET response. */
                     excludeFromPayload?: boolean;
                     /** @enum {string} */
                     inProgressConversions?: "loose" | "strict";
@@ -4605,6 +5082,83 @@ export interface operations {
                     "application/json": {
                         snapshot: components["schemas"]["ExperimentSnapshot"];
                     };
+                };
+            };
+        };
+    };
+    postVariationImageUpload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The id of the requested resource */
+                id: components["parameters"]["id"];
+                /** @description The variation ID (e.g. var_abc123) from the experiment's variations */
+                variationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Base64-encoded screenshot data */
+                    screenshot: string;
+                    /**
+                     * @description MIME type of the screenshot
+                     * @enum {string}
+                     */
+                    contentType: "image/png" | "image/jpeg" | "image/gif";
+                    /** @description Optional description for the screenshot */
+                    description?: string;
+                };
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        screenshot: {
+                            /** @description URL or path to the uploaded screenshot */
+                            path: string;
+                            /** @description Description of the screenshot */
+                            description: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    deleteVariationScreenshot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The id of the requested resource */
+                id: components["parameters"]["id"];
+                /** @description The variation ID (e.g. var_abc123) from the experiment's variations */
+                variationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The screenshot path/URL to delete (from upload response) */
+                    path: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Screenshot deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
         };
@@ -7021,6 +7575,838 @@ export interface operations {
             };
         };
     };
+    postMetricExploration: {
+        parameters: {
+            query?: {
+                cache?: "preferred" | "required" | "never";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description ID of the datasource to query */
+                    datasource: string;
+                    dimensions: ({
+                        /** @constant */
+                        dimensionType: "date";
+                        column: string | null;
+                        /** @enum {string} */
+                        dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                    } | {
+                        /** @constant */
+                        dimensionType: "dynamic";
+                        column: string | null;
+                        maxValues: number;
+                    } | {
+                        /** @constant */
+                        dimensionType: "static";
+                        column: string;
+                        values: string[];
+                    } | {
+                        /** @constant */
+                        dimensionType: "slice";
+                        slices: {
+                            name: string;
+                            filters: {
+                                /** @enum {string} */
+                                operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                column?: string;
+                                values?: string[];
+                            }[];
+                        }[];
+                    })[];
+                    /** @enum {string} */
+                    chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                    dateRange: {
+                        /** @enum {string} */
+                        predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                        lookbackValue: number | null;
+                        lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                        startDate: string | null;
+                        endDate: string | null;
+                    };
+                    /** @constant */
+                    type: "metric";
+                    dataset: {
+                        /** @constant */
+                        type: "metric";
+                        values: {
+                            name: string;
+                            rowFilters: {
+                                /** @enum {string} */
+                                operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                column?: string;
+                                values?: string[];
+                            }[];
+                            /** @constant */
+                            type: "metric";
+                            metricId: string;
+                            unit: string | null;
+                            denominatorUnit: string | null;
+                        }[];
+                    };
+                };
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        exploration: {
+                            id: string;
+                            /** Format: date-time */
+                            dateCreated: string;
+                            /** Format: date-time */
+                            dateUpdated: string;
+                            datasource: string;
+                            /** @enum {string} */
+                            status: "running" | "success" | "error";
+                            dateStart: string;
+                            dateEnd: string;
+                            error?: string | null;
+                            result: {
+                                rows: {
+                                    dimensions: (string | null)[];
+                                    values: {
+                                        metricId: string;
+                                        numerator: number | null;
+                                        denominator: number | null;
+                                    }[];
+                                }[];
+                            };
+                            config: {
+                                /** @description ID of the datasource to query */
+                                datasource: string;
+                                dimensions: ({
+                                    /** @constant */
+                                    dimensionType: "date";
+                                    column: string | null;
+                                    /** @enum {string} */
+                                    dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "dynamic";
+                                    column: string | null;
+                                    maxValues: number;
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "static";
+                                    column: string;
+                                    values: string[];
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "slice";
+                                    slices: {
+                                        name: string;
+                                        filters: {
+                                            /** @enum {string} */
+                                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                            column?: string;
+                                            values?: string[];
+                                        }[];
+                                    }[];
+                                })[];
+                                /** @enum {string} */
+                                chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                                dateRange: {
+                                    /** @enum {string} */
+                                    predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                                    lookbackValue: number | null;
+                                    lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                                    startDate: string | null;
+                                    endDate: string | null;
+                                };
+                                /** @constant */
+                                type: "metric";
+                                dataset: {
+                                    /** @constant */
+                                    type: "metric";
+                                    values: {
+                                        name: string;
+                                        rowFilters: {
+                                            /** @enum {string} */
+                                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                            column?: string;
+                                            values?: string[];
+                                        }[];
+                                        /** @constant */
+                                        type: "metric";
+                                        metricId: string;
+                                        unit: string | null;
+                                        denominatorUnit: string | null;
+                                    }[];
+                                };
+                            };
+                        } | null;
+                        query: {
+                            id: string;
+                            organization: string;
+                            datasource: string;
+                            language: string;
+                            query: string;
+                            queryType: string;
+                            createdAt: string;
+                            startedAt: string;
+                            /** @enum {string} */
+                            status: "running" | "queued" | "failed" | "partially-succeeded" | "succeeded";
+                            externalId: string;
+                            dependencies: string[];
+                            runAtEnd: boolean;
+                        } | null;
+                        /** @description Present when `exploration` is null, explaining why no result was returned. */
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postFactTableExploration: {
+        parameters: {
+            query?: {
+                cache?: "preferred" | "required" | "never";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description ID of the datasource to query */
+                    datasource: string;
+                    dimensions: ({
+                        /** @constant */
+                        dimensionType: "date";
+                        column: string | null;
+                        /** @enum {string} */
+                        dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                    } | {
+                        /** @constant */
+                        dimensionType: "dynamic";
+                        column: string | null;
+                        maxValues: number;
+                    } | {
+                        /** @constant */
+                        dimensionType: "static";
+                        column: string;
+                        values: string[];
+                    } | {
+                        /** @constant */
+                        dimensionType: "slice";
+                        slices: {
+                            name: string;
+                            filters: {
+                                /** @enum {string} */
+                                operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                column?: string;
+                                values?: string[];
+                            }[];
+                        }[];
+                    })[];
+                    /** @enum {string} */
+                    chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                    dateRange: {
+                        /** @enum {string} */
+                        predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                        lookbackValue: number | null;
+                        lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                        startDate: string | null;
+                        endDate: string | null;
+                    };
+                    /** @constant */
+                    type: "fact_table";
+                    dataset: {
+                        /** @constant */
+                        type: "fact_table";
+                        factTableId: string | null;
+                        values: {
+                            name: string;
+                            rowFilters: {
+                                /** @enum {string} */
+                                operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                column?: string;
+                                values?: string[];
+                            }[];
+                            /** @constant */
+                            type: "fact_table";
+                            /** @enum {string} */
+                            valueType: "unit_count" | "count" | "sum";
+                            valueColumn: string | null;
+                            unit: string | null;
+                        }[];
+                    };
+                };
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        exploration: {
+                            id: string;
+                            /** Format: date-time */
+                            dateCreated: string;
+                            /** Format: date-time */
+                            dateUpdated: string;
+                            datasource: string;
+                            /** @enum {string} */
+                            status: "running" | "success" | "error";
+                            dateStart: string;
+                            dateEnd: string;
+                            error?: string | null;
+                            result: {
+                                rows: {
+                                    dimensions: (string | null)[];
+                                    values: {
+                                        metricId: string;
+                                        numerator: number | null;
+                                        denominator: number | null;
+                                    }[];
+                                }[];
+                            };
+                            config: {
+                                /** @description ID of the datasource to query */
+                                datasource: string;
+                                dimensions: ({
+                                    /** @constant */
+                                    dimensionType: "date";
+                                    column: string | null;
+                                    /** @enum {string} */
+                                    dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "dynamic";
+                                    column: string | null;
+                                    maxValues: number;
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "static";
+                                    column: string;
+                                    values: string[];
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "slice";
+                                    slices: {
+                                        name: string;
+                                        filters: {
+                                            /** @enum {string} */
+                                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                            column?: string;
+                                            values?: string[];
+                                        }[];
+                                    }[];
+                                })[];
+                                /** @enum {string} */
+                                chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                                dateRange: {
+                                    /** @enum {string} */
+                                    predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                                    lookbackValue: number | null;
+                                    lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                                    startDate: string | null;
+                                    endDate: string | null;
+                                };
+                                /** @constant */
+                                type: "fact_table";
+                                dataset: {
+                                    /** @constant */
+                                    type: "fact_table";
+                                    factTableId: string | null;
+                                    values: {
+                                        name: string;
+                                        rowFilters: {
+                                            /** @enum {string} */
+                                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                            column?: string;
+                                            values?: string[];
+                                        }[];
+                                        /** @constant */
+                                        type: "fact_table";
+                                        /** @enum {string} */
+                                        valueType: "unit_count" | "count" | "sum";
+                                        valueColumn: string | null;
+                                        unit: string | null;
+                                    }[];
+                                };
+                            };
+                        } | null;
+                        query: {
+                            id: string;
+                            organization: string;
+                            datasource: string;
+                            language: string;
+                            query: string;
+                            queryType: string;
+                            createdAt: string;
+                            startedAt: string;
+                            /** @enum {string} */
+                            status: "running" | "queued" | "failed" | "partially-succeeded" | "succeeded";
+                            externalId: string;
+                            dependencies: string[];
+                            runAtEnd: boolean;
+                        } | null;
+                        /** @description Present when `exploration` is null, explaining why no result was returned. */
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postDataSourceExploration: {
+        parameters: {
+            query?: {
+                cache?: "preferred" | "required" | "never";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description ID of the datasource to query */
+                    datasource: string;
+                    dimensions: ({
+                        /** @constant */
+                        dimensionType: "date";
+                        column: string | null;
+                        /** @enum {string} */
+                        dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                    } | {
+                        /** @constant */
+                        dimensionType: "dynamic";
+                        column: string | null;
+                        maxValues: number;
+                    } | {
+                        /** @constant */
+                        dimensionType: "static";
+                        column: string;
+                        values: string[];
+                    } | {
+                        /** @constant */
+                        dimensionType: "slice";
+                        slices: {
+                            name: string;
+                            filters: {
+                                /** @enum {string} */
+                                operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                column?: string;
+                                values?: string[];
+                            }[];
+                        }[];
+                    })[];
+                    /** @enum {string} */
+                    chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                    dateRange: {
+                        /** @enum {string} */
+                        predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                        lookbackValue: number | null;
+                        lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                        startDate: string | null;
+                        endDate: string | null;
+                    };
+                    /** @constant */
+                    type: "data_source";
+                    dataset: {
+                        /** @constant */
+                        type: "data_source";
+                        table: string;
+                        path: string;
+                        timestampColumn: string;
+                        columnTypes: {
+                            [key: string]: "string" | "number" | "date" | "boolean" | "other";
+                        };
+                        values: {
+                            name: string;
+                            rowFilters: {
+                                /** @enum {string} */
+                                operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                column?: string;
+                                values?: string[];
+                            }[];
+                            /** @constant */
+                            type: "data_source";
+                            /** @enum {string} */
+                            valueType: "unit_count" | "count" | "sum";
+                            valueColumn: string | null;
+                            unit: string | null;
+                        }[];
+                    };
+                };
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        exploration: {
+                            id: string;
+                            /** Format: date-time */
+                            dateCreated: string;
+                            /** Format: date-time */
+                            dateUpdated: string;
+                            datasource: string;
+                            /** @enum {string} */
+                            status: "running" | "success" | "error";
+                            dateStart: string;
+                            dateEnd: string;
+                            error?: string | null;
+                            result: {
+                                rows: {
+                                    dimensions: (string | null)[];
+                                    values: {
+                                        metricId: string;
+                                        numerator: number | null;
+                                        denominator: number | null;
+                                    }[];
+                                }[];
+                            };
+                            config: {
+                                /** @description ID of the datasource to query */
+                                datasource: string;
+                                dimensions: ({
+                                    /** @constant */
+                                    dimensionType: "date";
+                                    column: string | null;
+                                    /** @enum {string} */
+                                    dateGranularity: "auto" | "hour" | "day" | "week" | "month" | "year";
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "dynamic";
+                                    column: string | null;
+                                    maxValues: number;
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "static";
+                                    column: string;
+                                    values: string[];
+                                } | {
+                                    /** @constant */
+                                    dimensionType: "slice";
+                                    slices: {
+                                        name: string;
+                                        filters: {
+                                            /** @enum {string} */
+                                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                            column?: string;
+                                            values?: string[];
+                                        }[];
+                                    }[];
+                                })[];
+                                /** @enum {string} */
+                                chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber";
+                                dateRange: {
+                                    /** @enum {string} */
+                                    predefined: "today" | "last7Days" | "last30Days" | "last90Days" | "customLookback" | "customDateRange";
+                                    lookbackValue: number | null;
+                                    lookbackUnit: ("hour" | "day" | "week" | "month") | null;
+                                    startDate: string | null;
+                                    endDate: string | null;
+                                };
+                                /** @constant */
+                                type: "data_source";
+                                dataset: {
+                                    /** @constant */
+                                    type: "data_source";
+                                    table: string;
+                                    path: string;
+                                    timestampColumn: string;
+                                    columnTypes: {
+                                        [key: string]: "string" | "number" | "date" | "boolean" | "other";
+                                    };
+                                    values: {
+                                        name: string;
+                                        rowFilters: {
+                                            /** @enum {string} */
+                                            operator: "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not_in" | "contains" | "not_contains" | "starts_with" | "ends_with" | "is_null" | "not_null" | "is_true" | "is_false" | "sql_expr" | "saved_filter";
+                                            column?: string;
+                                            values?: string[];
+                                        }[];
+                                        /** @constant */
+                                        type: "data_source";
+                                        /** @enum {string} */
+                                        valueType: "unit_count" | "count" | "sum";
+                                        valueColumn: string | null;
+                                        unit: string | null;
+                                    }[];
+                                };
+                            };
+                        } | null;
+                        query: {
+                            id: string;
+                            organization: string;
+                            datasource: string;
+                            language: string;
+                            query: string;
+                            queryType: string;
+                            createdAt: string;
+                            startedAt: string;
+                            /** @enum {string} */
+                            status: "running" | "queued" | "failed" | "partially-succeeded" | "succeeded";
+                            externalId: string;
+                            dependencies: string[];
+                            runAtEnd: boolean;
+                        } | null;
+                        /** @description Present when `exploration` is null, explaining why no result was returned. */
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    listCustomFields: {
+        parameters: {
+            query?: {
+                projectId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        /** Format: date-time */
+                        dateCreated: string;
+                        /** Format: date-time */
+                        dateUpdated: string;
+                        name: string;
+                        description?: string;
+                        placeholder?: string;
+                        defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+                        /** @enum {string} */
+                        type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
+                        values?: string;
+                        required: boolean;
+                        index?: boolean;
+                        creator?: string;
+                        projects?: string[];
+                        /** @enum {string} */
+                        section: "feature" | "experiment";
+                        active?: boolean;
+                    }[];
+                };
+            };
+        };
+    };
+    createCustomField: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The unique key for the custom field */
+                    id: string;
+                    /** @description The display name of the custom field */
+                    name: string;
+                    description?: string;
+                    placeholder?: string;
+                    defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+                    /**
+                     * @description The type of value this custom field will take
+                     * @enum {string}
+                     */
+                    type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
+                    values?: string;
+                    required: boolean;
+                    index?: boolean;
+                    projects?: string[];
+                    /**
+                     * @description What type of objects this custom field is applicable to
+                     * @enum {string}
+                     */
+                    section: "feature" | "experiment";
+                };
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        customField: {
+                            id: string;
+                            /** Format: date-time */
+                            dateCreated: string;
+                            /** Format: date-time */
+                            dateUpdated: string;
+                            name: string;
+                            description?: string;
+                            placeholder?: string;
+                            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+                            /** @enum {string} */
+                            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
+                            values?: string;
+                            required: boolean;
+                            index?: boolean;
+                            creator?: string;
+                            projects?: string[];
+                            /** @enum {string} */
+                            section: "feature" | "experiment";
+                            active?: boolean;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    getCustomField: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        customField: {
+                            id: string;
+                            /** Format: date-time */
+                            dateCreated: string;
+                            /** Format: date-time */
+                            dateUpdated: string;
+                            name: string;
+                            description?: string;
+                            placeholder?: string;
+                            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+                            /** @enum {string} */
+                            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
+                            values?: string;
+                            required: boolean;
+                            index?: boolean;
+                            creator?: string;
+                            projects?: string[];
+                            /** @enum {string} */
+                            section: "feature" | "experiment";
+                            active?: boolean;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    updateCustomField: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The display name of the custom field */
+                    name?: string;
+                    description?: string;
+                    placeholder?: string;
+                    defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+                    /**
+                     * @description The type of value this custom field will take
+                     * @enum {string}
+                     */
+                    type?: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
+                    values?: string;
+                    required?: boolean;
+                    index?: boolean;
+                    projects?: string[];
+                    /**
+                     * @description What type of objects this custom field is applicable to
+                     * @enum {string}
+                     */
+                    section?: "feature" | "experiment";
+                };
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        customField: {
+                            id: string;
+                            /** Format: date-time */
+                            dateCreated: string;
+                            /** Format: date-time */
+                            dateUpdated: string;
+                            name: string;
+                            description?: string;
+                            placeholder?: string;
+                            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+                            /** @enum {string} */
+                            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
+                            values?: string;
+                            required: boolean;
+                            index?: boolean;
+                            creator?: string;
+                            projects?: string[];
+                            /** @enum {string} */
+                            section: "feature" | "experiment";
+                            active?: boolean;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    deleteCustomField: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        deletedId: string;
+                    };
+                };
+            };
+        };
+    };
     getDashboard: {
         parameters: {
             query?: never;
@@ -7215,6 +8601,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -7287,6 +8674,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -7361,6 +8749,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -7729,6 +9118,7 @@ export interface operations {
                         snapshotId?: string;
                         explorerAnalysisId: string;
                         config: {
+                            /** @description ID of the datasource to query */
                             datasource: string;
                             dimensions: ({
                                 /** @constant */
@@ -7801,6 +9191,7 @@ export interface operations {
                         snapshotId?: string;
                         explorerAnalysisId: string;
                         config: {
+                            /** @description ID of the datasource to query */
                             datasource: string;
                             dimensions: ({
                                 /** @constant */
@@ -7875,6 +9266,7 @@ export interface operations {
                         snapshotId?: string;
                         explorerAnalysisId: string;
                         config: {
+                            /** @description ID of the datasource to query */
                             datasource: string;
                             dimensions: ({
                                 /** @constant */
@@ -8131,6 +9523,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -8203,6 +9596,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -8277,6 +9671,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -8567,6 +9962,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -8639,6 +10035,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -8713,6 +10110,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -9124,6 +10522,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -9196,6 +10595,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -9270,6 +10670,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -9539,6 +10940,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -9611,6 +11013,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -9685,6 +11088,7 @@ export interface operations {
                                 snapshotId?: string;
                                 explorerAnalysisId: string;
                                 config: {
+                                    /** @description ID of the datasource to query */
                                     datasource: string;
                                     dimensions: ({
                                         /** @constant */
@@ -9760,7 +11164,7 @@ export interface operations {
             };
         };
     };
-    listCustomFields: {
+    listExperimentTemplates: {
         parameters: {
             query?: {
                 projectId?: string;
@@ -9777,225 +11181,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        id: string;
-                        /** Format: date-time */
-                        dateCreated: string;
-                        /** Format: date-time */
-                        dateUpdated: string;
-                        name: string;
-                        description?: string;
-                        placeholder?: string;
-                        defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
-                        /** @enum {string} */
-                        type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
-                        values?: string;
-                        required: boolean;
-                        index?: boolean;
-                        creator?: string;
-                        projects?: string[];
-                        /** @enum {string} */
-                        section: "feature" | "experiment";
-                        active?: boolean;
-                    }[];
-                };
-            };
-        };
-    };
-    createCustomField: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description The unique key for the custom field */
-                    id: string;
-                    /** @description The display name of the custom field */
-                    name: string;
-                    description?: string;
-                    placeholder?: string;
-                    defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
-                    /**
-                     * @description The type of value this custom field will take
-                     * @enum {string}
-                     */
-                    type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
-                    values?: string;
-                    required: boolean;
-                    index?: boolean;
-                    projects?: string[];
-                    /**
-                     * @description What type of objects this custom field is applicable to
-                     * @enum {string}
-                     */
-                    section: "feature" | "experiment";
-                };
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        customField: {
+                        experimentTemplates: {
                             id: string;
                             /** Format: date-time */
                             dateCreated: string;
                             /** Format: date-time */
                             dateUpdated: string;
-                            name: string;
+                            project?: string;
+                            owner: string;
+                            templateMetadata: {
+                                name: string;
+                                description?: string;
+                            };
+                            /** @enum {string} */
+                            type: "standard";
+                            hypothesis?: string;
                             description?: string;
-                            placeholder?: string;
-                            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
+                            tags?: string[];
+                            customFields?: {
+                                [key: string]: string;
+                            };
+                            datasource: string;
+                            exposureQueryId: string;
+                            hashAttribute?: string;
+                            fallbackAttribute?: string;
+                            disableStickyBucketing?: boolean;
+                            goalMetrics?: string[];
+                            secondaryMetrics?: string[];
+                            guardrailMetrics?: string[];
+                            activationMetric?: string;
                             /** @enum {string} */
-                            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
-                            values?: string;
-                            required: boolean;
-                            index?: boolean;
-                            creator?: string;
-                            projects?: string[];
-                            /** @enum {string} */
-                            section: "feature" | "experiment";
-                            active?: boolean;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    getCustomField: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        customField: {
-                            id: string;
-                            /** Format: date-time */
-                            dateCreated: string;
-                            /** Format: date-time */
-                            dateUpdated: string;
-                            name: string;
-                            description?: string;
-                            placeholder?: string;
-                            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
-                            /** @enum {string} */
-                            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
-                            values?: string;
-                            required: boolean;
-                            index?: boolean;
-                            creator?: string;
-                            projects?: string[];
-                            /** @enum {string} */
-                            section: "feature" | "experiment";
-                            active?: boolean;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    updateCustomField: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description The display name of the custom field */
-                    name?: string;
-                    description?: string;
-                    placeholder?: string;
-                    defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
-                    /**
-                     * @description The type of value this custom field will take
-                     * @enum {string}
-                     */
-                    type?: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
-                    values?: string;
-                    required?: boolean;
-                    index?: boolean;
-                    projects?: string[];
-                    /**
-                     * @description What type of objects this custom field is applicable to
-                     * @enum {string}
-                     */
-                    section?: "feature" | "experiment";
-                };
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        customField: {
-                            id: string;
-                            /** Format: date-time */
-                            dateCreated: string;
-                            /** Format: date-time */
-                            dateUpdated: string;
-                            name: string;
-                            description?: string;
-                            placeholder?: string;
-                            defaultValue?: string | number | boolean | string[] | number[] | boolean[] | string[] | string[];
-                            /** @enum {string} */
-                            type: "text" | "textarea" | "markdown" | "enum" | "multiselect" | "url" | "number" | "boolean" | "date" | "datetime";
-                            values?: string;
-                            required: boolean;
-                            index?: boolean;
-                            creator?: string;
-                            projects?: string[];
-                            /** @enum {string} */
-                            section: "feature" | "experiment";
-                            active?: boolean;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    deleteCustomField: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        deletedId: string;
+                            statsEngine: "bayesian" | "frequentist";
+                            segment?: string;
+                            skipPartialData?: boolean;
+                            targeting: {
+                                coverage: number;
+                                savedGroups?: {
+                                    /** @enum {string} */
+                                    match: "all" | "none" | "any";
+                                    ids: string[];
+                                }[];
+                                prerequisites?: {
+                                    id: string;
+                                    condition: string;
+                                }[];
+                                condition: string;
+                            };
+                            customMetricSlices?: {
+                                slices: {
+                                    column: string;
+                                    levels: string[];
+                                }[];
+                            }[];
+                        }[];
                     };
                 };
             };

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -663,6 +663,103 @@ export function formatStaleFeatureFlags(
   return parts.join("\n");
 }
 
+// ─── Product Analytics Explorations ─────────────────────────────────
+export function formatMetricExploration(
+  data: {
+    exploration: {
+      id: string;
+      status: "running" | "success" | "error";
+      dateStart: string;
+      dateEnd: string;
+      error?: string | null;
+      result: {
+        rows: {
+          dimensions: (string | null)[];
+          values: { metricId: string; numerator: number | null; denominator: number | null }[];
+        }[];
+      };
+    } | null;
+    query: {
+      status: "running" | "queued" | "failed" | "partially-succeeded" | "succeeded";
+    } | null;
+    explorationUrl?: string;
+    message?: string;
+  },
+  metricName: string
+): string {
+  const parts: string[] = [];
+
+  if (!data.exploration) {
+    parts.push(`**Metric exploration for ${metricName} could not be created.**`);
+    if (data.message) parts.push(data.message);
+    if (data.query) parts.push(`Query status: ${data.query.status}`);
+    return parts.join("\n");
+  }
+
+  const { exploration } = data;
+
+  if (exploration.status === "running") {
+    parts.push(`**Metric exploration for ${metricName} is still running.**`);
+    parts.push(`Query status: ${data.query?.status || "unknown"}`);
+    parts.push("The query has not completed yet. Try again shortly.");
+    return parts.join("\n");
+  }
+
+  if (exploration.status === "error") {
+    parts.push(`**Metric exploration for ${metricName} failed.**`);
+    if (exploration.error) parts.push(`Error: ${exploration.error}`);
+    return parts.join("\n");
+  }
+
+  // Success
+  parts.push(`**Metric exploration: ${metricName}**`);
+  parts.push(`Date range: ${exploration.dateStart} to ${exploration.dateEnd}`);
+
+  const rows = exploration.result?.rows || [];
+  parts.push(`Data points: ${rows.length}`);
+
+  if (rows.length > 0) {
+    const dimCount = rows[0].dimensions.length;
+    const hasBreakdown = dimCount > 1;
+
+    parts.push("");
+
+    if (hasBreakdown) {
+      parts.push("| Date | Dimension | Value |");
+      parts.push("|------|-----------|-------|");
+    } else {
+      parts.push("| Date | Value |");
+      parts.push("|------|-------|");
+    }
+
+    const displayRows = rows.slice(0, 30);
+    for (const row of displayRows) {
+      const date = row.dimensions[0] ?? "—";
+      const value = row.values[0]?.numerator;
+      const formatted = value != null ? value.toLocaleString() : "—";
+
+      if (hasBreakdown) {
+        const dimension = row.dimensions.slice(1).join(", ") || "—";
+        parts.push(`| ${date} | ${dimension} | ${formatted} |`);
+      } else {
+        parts.push(`| ${date} | ${formatted} |`);
+      }
+    }
+
+    if (rows.length > 30) {
+      const cols = hasBreakdown ? "| ... | ... |" : "| ... |";
+      parts.push(`${cols} *(${rows.length - 30} more rows)* |`);
+    }
+  }
+
+  if (data.explorationUrl) {
+    parts.push("");
+    parts.push(`[View chart in GrowthBook](${data.explorationUrl})`);
+  }
+
+  return parts.join("\n");
+}
+
 // ─── Helpful Errors ─────────────────────────────────────────────────
 export function formatApiError(
   error: unknown,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { getApiKey, getApiUrl, getAppOrigin } from "./utils.js";
 import { registerSearchTools } from "./tools/search.js";
 import { registerDefaultsTools } from "./tools/defaults.js";
 import { registerMetricsTools } from "./tools/metrics.js";
+import { registerProductAnalyticsTools } from "./tools/product-analytics.js";
 import { registerExperimentPrompts } from "./prompts/experiment-prompts.js";
 import packageDetails from "../package.json" with { type: "json" };
 
@@ -38,6 +39,7 @@ Key workflows:
 - Feature flags: Use create_feature_flag for simple flags, then create_force_rule to add targeting conditions
 - Experiments: ALWAYS call get_defaults first, then create_experiment. Experiments are created as "draft" - users must launch in GrowthBook UI
 - Analysis: Use get_experiments with mode="summary" for quick insights
+- Product analytics: Use create_metric_exploration to chart metric data. Use get_metrics first to find the metric ID.
 
 All mutating tools require a fileExtension parameter for SDK integration guidance.`,
     capabilities: {
@@ -97,6 +99,13 @@ registerMetricsTools({
   apiKey,
   appOrigin,
   user,
+});
+
+registerProductAnalyticsTools({
+  server,
+  baseApiUrl,
+  apiKey,
+  appOrigin,
 });
 
 registerExperimentPrompts({

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -84,12 +84,19 @@ export function registerProductAnalyticsTools({
     {
       title: "Create Metric Exploration",
       description:
-        "Charts an existing GrowthBook fact metric (IDs starting with 'fact__'), either as a time series or a cumulative chart. Requires a fact metric ID — use `get_metrics` to find one. Standard (non-fact) metrics are not supported. Returns chart data and a link to view the visualization in GrowthBook. If no fact metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
+        "Charts an existing GrowthBook fact metric (IDs starting with 'fact__'), either as a time series or a cumulative chart. " +
+        "Legacy/standard metrics (IDs starting with 'met_') are NOT supported and will return an error — only fact metrics can be charted. " +
+        "Use `get_metrics` to find a fact metric ID. If the user references a metric by name, match it to a fact metric first — prefer fact metrics over legacy equivalents. " +
+        "Returns chart data and a link to view the visualization in GrowthBook. " +
+        "The underlying query may take time to execute. If the response indicates the query is still running, wait 10–15 seconds and retry with cache 'preferred' to pick up the completed result. " +
+        "If no fact metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
       inputSchema: z.object({
         metricId: z
           .string()
           .describe(
-            "The ID of the fact metric to chart (must start with 'fact__'). Standard metrics are not supported. Use get_metrics to find available fact metric IDs."
+            "The ID of the fact metric to chart (must start with 'fact__'). Legacy/standard metrics (IDs starting with 'met_') are not supported. " +
+            "Use get_metrics to find available metrics, then match the user's intent to the closest fact metric by name. " +
+            "If no fact metric matches but a legacy metric does, inform the user that only fact metrics can be charted."
           ),
         dateRange: z
           .enum([
@@ -240,13 +247,15 @@ export function registerProductAnalyticsTools({
           )
           .optional()
           .describe(
-            "Dimensions to break down the data. For timeseries charts (line, area, timeseries-table), a date dimension is auto-included if not explicitly provided. For cumulative charts (bar, table, bigNumber), omit the date dimension. Types: 'date' for time axis, 'dynamic' for top-N grouping, 'static' for specific values, 'slice' for custom named segments."
+            "Dimensions to break down the data. For timeseries charts (line, area, timeseries-table), a date dimension is auto-included if not explicitly provided. For cumulative charts (bar, table, bigNumber), omit the date dimension. " +
+            "Types: 'date' for time axis, 'dynamic' for top-N grouping, 'static' for specific values, 'slice' for custom named segments. " +
+            "Prefer 'dynamic' over 'static' for group-by dimensions — 'static' and 'slice' dimensions work in the API response but are not yet fully supported in the GrowthBook UI chart view. Use 'dynamic' for results that render correctly in both the API and the GrowthBook link."
           ),
         name: z
           .string()
           .optional()
           .describe(
-            "Display name for the metric series. Defaults to the metric name."
+            "Display name for the metric series in the chart legend and GrowthBook UI. Defaults to the metric name. Use this to give the chart a custom title when the user requests one."
           ),
       }),
       annotations: {

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -84,9 +84,10 @@ export function registerProductAnalyticsTools({
     {
       title: "Create Metric Exploration",
       description:
+        "This tool can be used to answer questions about Fact Metrics in GrowthBook. " +
         "Charts an existing GrowthBook fact metric (IDs starting with 'fact__'), either as a time series or a cumulative chart. " +
         "Legacy/standard metrics (IDs starting with 'met_') are NOT supported and will return an error — only fact metrics can be charted. " +
-        "Use `get_metrics` to find a fact metric ID. If the user references a metric by name, match it to a fact metric first — prefer fact metrics over legacy equivalents. " +
+        "Use `get_metrics` to find a fact metric ID. If the user references a metric by name, match it to a fact metric. This tool does not support legacy metrics. " +
         "Returns chart data and a link to view the visualization in GrowthBook. " +
         "The underlying query may take time to execute. If the response indicates the query is still running, wait 10–15 seconds and retry with cache 'preferred' to pick up the completed result. " +
         "If no fact metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
@@ -95,8 +96,8 @@ export function registerProductAnalyticsTools({
           .string()
           .describe(
             "The ID of the fact metric to chart (must start with 'fact__'). Legacy/standard metrics (IDs starting with 'met_') are not supported. " +
-            "Use get_metrics to find available metrics, then match the user's intent to the closest fact metric by name. " +
-            "If no fact metric matches but a legacy metric does, inform the user that only fact metrics can be charted."
+              "Use get_metrics to find available metrics, then match the user's intent to the closest fact metric by name. " +
+              "If no fact metric matches but a legacy metric does, inform the user that only fact metrics can be charted."
           ),
         dateRange: z
           .enum([
@@ -248,8 +249,8 @@ export function registerProductAnalyticsTools({
           .optional()
           .describe(
             "Dimensions to break down the data. For timeseries charts (line, area, timeseries-table), a date dimension is auto-included if not explicitly provided. For cumulative charts (bar, table, bigNumber), omit the date dimension. " +
-            "Types: 'date' for time axis, 'dynamic' for top-N grouping, 'static' for specific values, 'slice' for custom named segments. " +
-            "Prefer 'dynamic' over 'static' for group-by dimensions — 'static' and 'slice' dimensions work in the API response but are not yet fully supported in the GrowthBook UI chart view. Use 'dynamic' for results that render correctly in both the API and the GrowthBook link."
+              "Types: 'date' for time axis, 'dynamic' for top-N grouping, 'static' for specific values, 'slice' for custom named segments. " +
+              "Prefer 'dynamic' over 'static' for group-by dimensions — 'static' and 'slice' dimensions work in the API response but are not yet fully supported in the GrowthBook UI chart view. Use 'dynamic' for results that render correctly in both the API and the GrowthBook link."
           ),
         name: z
           .string()

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -1,0 +1,285 @@
+import { z } from "zod";
+import {
+  type BaseToolsInterface,
+  handleResNotOk,
+  fetchWithRateLimit,
+  buildHeaders,
+} from "../utils.js";
+import type { CreateExplorationResponse } from "../api-type-helpers.js";
+import {
+  formatMetricExploration,
+  formatApiError,
+} from "../format-responses.js";
+
+interface ProductAnalyticsTools extends BaseToolsInterface {
+  appOrigin: string;
+}
+
+async function resolveMetricDatasource(
+  baseApiUrl: string,
+  apiKey: string,
+  metricId: string
+): Promise<{ datasource: string; metricName: string }> {
+  const isFactMetric = metricId.startsWith("fact__");
+  const endpoint = isFactMetric
+    ? `${baseApiUrl}/api/v1/fact-metrics/${metricId}`
+    : `${baseApiUrl}/api/v1/metrics/${metricId}`;
+
+  const res = await fetchWithRateLimit(endpoint, {
+    headers: buildHeaders(apiKey),
+  });
+  await handleResNotOk(res);
+  const data = await res.json();
+
+  const metric = isFactMetric ? data.factMetric : data.metric;
+  const datasource = isFactMetric ? metric.datasource : metric.datasourceId;
+  const metricName = metric.name || metricId;
+
+  if (!datasource) {
+    throw new Error(
+      `Metric '${metricId}' does not have a datasource configured.`
+    );
+  }
+
+  return { datasource, metricName };
+}
+
+export function registerProductAnalyticsTools({
+  server,
+  baseApiUrl,
+  apiKey,
+  appOrigin,
+}: ProductAnalyticsTools) {
+  server.registerTool(
+    "create_metric_exploration",
+    {
+      title: "Create Metric Exploration",
+      description:
+        "Charts an existing GrowthBook metric over time. Requires a metricId — use `get_metrics` to find one. Returns chart data and a link to view the visualization in GrowthBook. If no metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
+      inputSchema: z.object({
+        metricId: z
+          .string()
+          .describe(
+            "The ID of the metric to chart. Use get_metrics to find available metric IDs."
+          ),
+        dateRange: z
+          .enum([
+            "today",
+            "last7Days",
+            "last30Days",
+            "last90Days",
+            "customLookback",
+            "customDateRange",
+          ])
+          .default("last30Days")
+          .describe(
+            "Date range for the chart. Use a predefined range, 'customLookback' with lookbackValue/lookbackUnit, or 'customDateRange' with startDate/endDate."
+          ),
+        lookbackValue: z
+          .number()
+          .optional()
+          .describe(
+            "Number of time units to look back. Only used when dateRange is 'customLookback'. Example: 14 with lookbackUnit 'day' = last 14 days."
+          ),
+        lookbackUnit: z
+          .enum(["hour", "day", "week", "month"])
+          .optional()
+          .describe(
+            "Time unit for the lookback. Only used when dateRange is 'customLookback'."
+          ),
+        startDate: z
+          .string()
+          .optional()
+          .describe(
+            "Start date for custom date range (ISO 8601 format, e.g. '2025-01-01'). Only used when dateRange is 'customDateRange'."
+          ),
+        endDate: z
+          .string()
+          .optional()
+          .describe(
+            "End date for custom date range (ISO 8601 format, e.g. '2025-03-31'). Only used when dateRange is 'customDateRange'."
+          ),
+        chartType: z
+          .enum([
+            "line",
+            "area",
+            "timeseries-table",
+            "table",
+            "bar",
+            "stackedBar",
+            "horizontalBar",
+            "stackedHorizontalBar",
+            "bigNumber",
+          ])
+          .default("line")
+          .describe("The type of chart to render."),
+        dateGranularity: z
+          .enum(["auto", "hour", "day", "week", "month", "year"])
+          .default("auto")
+          .describe("Granularity for the date dimension."),
+        dimensions: z
+          .array(
+            z.discriminatedUnion("dimensionType", [
+              z.object({
+                dimensionType: z.literal("dynamic"),
+                column: z
+                  .string()
+                  .describe(
+                    "Column name to group by (e.g. 'country', 'device_type'). Shows the top N values."
+                  ),
+                maxValues: z
+                  .number()
+                  .default(10)
+                  .describe("Maximum number of distinct values to return."),
+              }),
+              z.object({
+                dimensionType: z.literal("static"),
+                column: z
+                  .string()
+                  .describe("Column name to group by (e.g. 'country')."),
+                values: z
+                  .array(z.string())
+                  .describe(
+                    "Specific values to include (e.g. ['US', 'CA', 'UK']). Only these values will appear in the results."
+                  ),
+              }),
+              z.object({
+                dimensionType: z.literal("slice"),
+                slices: z
+                  .array(
+                    z.object({
+                      name: z
+                        .string()
+                        .describe(
+                          "Display name for this slice (e.g. 'North America', 'Mobile users')."
+                        ),
+                      filters: z
+                        .array(
+                          z.object({
+                            operator: z.enum([
+                              "=",
+                              "!=",
+                              "<",
+                              "<=",
+                              ">",
+                              ">=",
+                              "in",
+                              "not_in",
+                              "contains",
+                              "not_contains",
+                              "starts_with",
+                              "ends_with",
+                              "is_null",
+                              "not_null",
+                              "is_true",
+                              "is_false",
+                              "sql_expr",
+                              "saved_filter",
+                            ]),
+                            column: z.string().optional(),
+                            values: z.array(z.string()).optional(),
+                          })
+                        )
+                        .describe("Filters that define this slice."),
+                    })
+                  )
+                  .describe(
+                    "Named slices, each defined by a set of filters. Use for custom groupings like 'North America' = country in ['US','CA']."
+                  ),
+              }),
+            ])
+          )
+          .optional()
+          .describe(
+            "Additional dimensions to break down the data. The date dimension is always included automatically. Use 'dynamic' for top-N grouping (e.g. top 10 countries), 'static' for specific values (e.g. only US, CA, UK), or 'slice' for custom named segments with filters."
+          ),
+        name: z
+          .string()
+          .optional()
+          .describe(
+            "Display name for the metric series. Defaults to the metric name."
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+      },
+    },
+    async ({ metricId, dateRange, lookbackValue, lookbackUnit, startDate, endDate, chartType, dateGranularity, dimensions, name }) => {
+      try {
+        const { datasource, metricName } = await resolveMetricDatasource(
+          baseApiUrl,
+          apiKey,
+          metricId
+        );
+
+        const seriesName = name || metricName;
+
+        const payload = {
+          datasource,
+          type: "metric" as const,
+          chartType,
+          dateRange: {
+            predefined: dateRange,
+            lookbackValue: dateRange === "customLookback" ? (lookbackValue ?? null) : null,
+            lookbackUnit: dateRange === "customLookback" ? (lookbackUnit ?? null) : null,
+            startDate: dateRange === "customDateRange" ? (startDate ?? null) : null,
+            endDate: dateRange === "customDateRange" ? (endDate ?? null) : null,
+          },
+          dimensions: [
+            {
+              dimensionType: "date" as const,
+              column: null,
+              dateGranularity,
+            },
+            ...(dimensions || []),
+          ],
+          dataset: {
+            type: "metric" as const,
+            values: [
+              {
+                name: seriesName,
+                type: "metric" as const,
+                metricId,
+                rowFilters: [],
+                unit: null,
+                denominatorUnit: null,
+              },
+            ],
+          },
+        };
+
+        const res = await fetchWithRateLimit(
+          `${baseApiUrl}/api/v1/product-analytics/metric-exploration`,
+          {
+            method: "POST",
+            headers: buildHeaders(apiKey),
+            body: JSON.stringify(payload),
+          }
+        );
+
+        await handleResNotOk(res);
+
+        const data = (await res.json()) as CreateExplorationResponse & {
+          explorationUrl?: string;
+        };
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatMetricExploration(data, seriesName),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(error, `creating metric exploration for '${metricId}'`, [
+            "Check that the metric ID is correct — use get_metrics to list available metrics.",
+            "Fact metric IDs start with 'fact__'.",
+            "If no metric matches, consider charting from a fact table or data source instead.",
+          ])
+        );
+      }
+    }
+  );
+}

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -15,29 +15,33 @@ interface ProductAnalyticsTools extends BaseToolsInterface {
   appOrigin: string;
 }
 
-async function resolveMetricDatasource(
+async function resolveFactMetricDatasource(
   baseApiUrl: string,
   apiKey: string,
   metricId: string
 ): Promise<{ datasource: string; metricName: string }> {
-  const isFactMetric = metricId.startsWith("fact__");
-  const endpoint = isFactMetric
-    ? `${baseApiUrl}/api/v1/fact-metrics/${metricId}`
-    : `${baseApiUrl}/api/v1/metrics/${metricId}`;
+  if (!metricId.startsWith("fact__")) {
+    throw new Error(
+      `Metric explorations only support fact metrics (IDs starting with 'fact__'). ` +
+        `The metric '${metricId}' is a standard metric. ` +
+        `Use get_metrics to find a fact metric ID instead.`
+    );
+  }
 
-  const res = await fetchWithRateLimit(endpoint, {
-    headers: buildHeaders(apiKey),
-  });
+  const res = await fetchWithRateLimit(
+    `${baseApiUrl}/api/v1/fact-metrics/${metricId}`,
+    { headers: buildHeaders(apiKey) }
+  );
   await handleResNotOk(res);
   const data = await res.json();
 
-  const metric = isFactMetric ? data.factMetric : data.metric;
-  const datasource = isFactMetric ? metric.datasource : metric.datasourceId;
+  const metric = data.factMetric;
+  const datasource = metric.datasource;
   const metricName = metric.name || metricId;
 
   if (!datasource) {
     throw new Error(
-      `Metric '${metricId}' does not have a datasource configured.`
+      `Fact metric '${metricId}' does not have a datasource configured.`
     );
   }
 
@@ -80,12 +84,12 @@ export function registerProductAnalyticsTools({
     {
       title: "Create Metric Exploration",
       description:
-        "Charts an existing GrowthBook metric, either as a time series or a cumulative chart. Requires a metricId — use `get_metrics` to find one. Returns chart data and a link to view the visualization in GrowthBook. If no metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
+        "Charts an existing GrowthBook fact metric (IDs starting with 'fact__'), either as a time series or a cumulative chart. Requires a fact metric ID — use `get_metrics` to find one. Standard (non-fact) metrics are not supported. Returns chart data and a link to view the visualization in GrowthBook. If no fact metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
       inputSchema: z.object({
         metricId: z
           .string()
           .describe(
-            "The ID of the metric to chart. Use get_metrics to find available metric IDs."
+            "The ID of the fact metric to chart (must start with 'fact__'). Standard metrics are not supported. Use get_metrics to find available fact metric IDs."
           ),
         dateRange: z
           .enum([
@@ -149,7 +153,9 @@ export function registerProductAnalyticsTools({
         dateGranularity: z
           .enum(["auto", "hour", "day", "week", "month", "year"])
           .default("auto")
-          .describe("Granularity for the date dimension."),
+          .describe(
+            "Granularity for the date dimension. Depending on the amount of time scanned, the granularity might be automatically adjusted to a less granular level to reduce the number of data points."
+          ),
         dimensions: z
           .array(
             z.discriminatedUnion("dimensionType", [
@@ -261,7 +267,7 @@ export function registerProductAnalyticsTools({
       name,
     }) => {
       try {
-        const { datasource, metricName } = await resolveMetricDatasource(
+        const { datasource, metricName } = await resolveFactMetricDatasource(
           baseApiUrl,
           apiKey,
           metricId
@@ -328,9 +334,9 @@ export function registerProductAnalyticsTools({
             error,
             `creating metric exploration for '${metricId}'`,
             [
-              "Check that the metric ID is correct — use get_metrics to list available metrics.",
-              "Fact metric IDs start with 'fact__'.",
-              "If no metric matches, consider charting from a fact table or data source instead.",
+              "Only fact metrics are supported — IDs must start with 'fact__'.",
+              "Use get_metrics to find available fact metric IDs.",
+              "If no fact metric matches, consider charting from a fact table or data source instead.",
             ]
           )
         );

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -44,6 +44,31 @@ async function resolveMetricDatasource(
   return { datasource, metricName };
 }
 
+const TIMESERIES_CHART_TYPES = new Set(["line", "area", "timeseries-table"]);
+
+function buildDimensions(
+  dimensions: Array<Record<string, unknown>> | undefined,
+  chartType: string,
+  dateGranularity: string
+): Array<Record<string, unknown>> {
+  const dims = (dimensions || []).map((d) => {
+    if (d.dimensionType === "date" && !d.column) {
+      return { ...d, column: "date" };
+    }
+    return d;
+  });
+  const hasDateDimension = dims.some((d) => d.dimensionType === "date");
+
+  if (!hasDateDimension && TIMESERIES_CHART_TYPES.has(chartType)) {
+    return [
+      { dimensionType: "date", column: "date", dateGranularity },
+      ...dims,
+    ];
+  }
+
+  return dims;
+}
+
 export function registerProductAnalyticsTools({
   server,
   baseApiUrl,
@@ -55,7 +80,7 @@ export function registerProductAnalyticsTools({
     {
       title: "Create Metric Exploration",
       description:
-        "Charts an existing GrowthBook metric over time. Requires a metricId — use `get_metrics` to find one. Returns chart data and a link to view the visualization in GrowthBook. If no metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
+        "Charts an existing GrowthBook metric, either as a time series or a cumulative chart. Requires a metricId — use `get_metrics` to find one. Returns chart data and a link to view the visualization in GrowthBook. If no metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
       inputSchema: z.object({
         metricId: z
           .string()
@@ -99,6 +124,12 @@ export function registerProductAnalyticsTools({
           .describe(
             "End date for custom date range (ISO 8601 format, e.g. '2025-03-31'). Only used when dateRange is 'customDateRange'."
           ),
+        cache: z
+          .enum(["preferred", "required", "never"])
+          .default("preferred")
+          .describe(
+            "Cache behavior: 'preferred' (default) returns cached results if available, otherwise runs a new query; 'never' always runs a fresh query; 'required' only returns cached results or null if none exist."
+          ),
         chartType: z
           .enum([
             "line",
@@ -112,7 +143,9 @@ export function registerProductAnalyticsTools({
             "bigNumber",
           ])
           .default("line")
-          .describe("The type of chart to render."),
+          .describe(
+            "The type of chart to render. Chart mode vs time series: line, area, and timeseries-table charts are always timeseries — these must include a date dimension. Bar charts (bar, stackedBar, horizontalBar, stackedHorizontalBar), the plain table chart, and bigNumber are cumulative — thesedo not use a date dimension. When switching between timeseries and cumulative chart types, add or remove the date dimension accordingly"
+          ),
         dateGranularity: z
           .enum(["auto", "hour", "day", "week", "month", "year"])
           .default("auto")
@@ -120,6 +153,16 @@ export function registerProductAnalyticsTools({
         dimensions: z
           .array(
             z.discriminatedUnion("dimensionType", [
+              z.object({
+                dimensionType: z.literal("date"),
+                column: z
+                  .string()
+                  .default("date")
+                  .describe("Date column name."),
+                dateGranularity: z
+                  .enum(["auto", "hour", "day", "week", "month", "year"])
+                  .describe("Granularity for the date axis."),
+              }),
               z.object({
                 dimensionType: z.literal("dynamic"),
                 column: z
@@ -191,7 +234,7 @@ export function registerProductAnalyticsTools({
           )
           .optional()
           .describe(
-            "Additional dimensions to break down the data. The date dimension is always included automatically. Use 'dynamic' for top-N grouping (e.g. top 10 countries), 'static' for specific values (e.g. only US, CA, UK), or 'slice' for custom named segments with filters."
+            "Dimensions to break down the data. For timeseries charts (line, area, timeseries-table), a date dimension is auto-included if not explicitly provided. For cumulative charts (bar, table, bigNumber), omit the date dimension. Types: 'date' for time axis, 'dynamic' for top-N grouping, 'static' for specific values, 'slice' for custom named segments."
           ),
         name: z
           .string()
@@ -204,7 +247,19 @@ export function registerProductAnalyticsTools({
         readOnlyHint: false,
       },
     },
-    async ({ metricId, dateRange, lookbackValue, lookbackUnit, startDate, endDate, chartType, dateGranularity, dimensions, name }) => {
+    async ({
+      metricId,
+      dateRange,
+      lookbackValue,
+      lookbackUnit,
+      startDate,
+      endDate,
+      cache,
+      chartType,
+      dateGranularity,
+      dimensions,
+      name,
+    }) => {
       try {
         const { datasource, metricName } = await resolveMetricDatasource(
           baseApiUrl,
@@ -220,19 +275,15 @@ export function registerProductAnalyticsTools({
           chartType,
           dateRange: {
             predefined: dateRange,
-            lookbackValue: dateRange === "customLookback" ? (lookbackValue ?? null) : null,
-            lookbackUnit: dateRange === "customLookback" ? (lookbackUnit ?? null) : null,
-            startDate: dateRange === "customDateRange" ? (startDate ?? null) : null,
-            endDate: dateRange === "customDateRange" ? (endDate ?? null) : null,
+            lookbackValue:
+              dateRange === "customLookback" ? lookbackValue ?? null : null,
+            lookbackUnit:
+              dateRange === "customLookback" ? lookbackUnit ?? null : null,
+            startDate:
+              dateRange === "customDateRange" ? startDate ?? null : null,
+            endDate: dateRange === "customDateRange" ? endDate ?? null : null,
           },
-          dimensions: [
-            {
-              dimensionType: "date" as const,
-              column: null,
-              dateGranularity,
-            },
-            ...(dimensions || []),
-          ],
+          dimensions: buildDimensions(dimensions, chartType, dateGranularity),
           dataset: {
             type: "metric" as const,
             values: [
@@ -249,7 +300,7 @@ export function registerProductAnalyticsTools({
         };
 
         const res = await fetchWithRateLimit(
-          `${baseApiUrl}/api/v1/product-analytics/metric-exploration`,
+          `${baseApiUrl}/api/v1/product-analytics/metric-exploration?cache=${cache}`,
           {
             method: "POST",
             headers: buildHeaders(apiKey),
@@ -273,11 +324,15 @@ export function registerProductAnalyticsTools({
         };
       } catch (error) {
         throw new Error(
-          formatApiError(error, `creating metric exploration for '${metricId}'`, [
-            "Check that the metric ID is correct — use get_metrics to list available metrics.",
-            "Fact metric IDs start with 'fact__'.",
-            "If no metric matches, consider charting from a fact table or data source instead.",
-          ])
+          formatApiError(
+            error,
+            `creating metric exploration for '${metricId}'`,
+            [
+              "Check that the metric ID is correct — use get_metrics to list available metrics.",
+              "Fact metric IDs start with 'fact__'.",
+              "If no metric matches, consider charting from a fact table or data source instead.",
+            ]
+          )
         );
       }
     }


### PR DESCRIPTION
### Features and Changes

Adds a new `create_metric_exploration` tool that lets AI agents chart GrowthBook metrics via the product analytics API. Given a metric ID (obtained via `get_metrics`), the tool:

- Resolves the metric's datasource automatically (this tool only supports fact metrics)
- Builds and submits an exploration query with configurable date ranges, chart types, granularity, and dimension breakdowns (dynamic top-N, static value lists, and custom named slices)
- Auto-injects a date dimension for timeseries chart types (`line`, `area`, `timeseries-table`) so agents don't need to manually manage it
- Returns formatted chart data as a markdown table plus a link to view the visualization in GrowthBook

This enables a natural workflow: agent calls `get_metrics` to find a metric ID, then calls `create_metric_exploration` to chart it — giving users quick access to product analytics data directly from their AI assistant.

> [!NOTE]
> The backend and this tool currently support all dimension types, whereas the front-end only supports the dynamic dimensions, so its possible that a user could get into a weird state.

### Dependencies

None

### Testing

- [x] **Basic line chart** — call `create_metric_exploration` with just a `metricId` and default params (`dateRange: last30Days`, `chartType: line`). Verify it returns a markdown table with date/value rows and a GrowthBook link.
- [x] **Fact metric resolution** — use a fact metric ID (starts with `fact__`). Verify the tool correctly resolves its datasource via `/api/v1/fact-metrics/` and produces chart data.
- [x] **Standard metric resolution** — use a non-fact metric ID. Verify it resolves returns an error before hitting the API
- [x] **Invalid metric ID** — pass a bogus metric ID. Verify the error message includes actionable suggestions (use `get_metrics`, fact metric prefix hint, etc.).
- [x] **Each predefined date range** — test each of `today`, `last7Days`, `last30Days`, `last90Days` individually. Verify the returned date range in the response matches expectations.
- [x] **Custom lookback** — use `dateRange: customLookback` with `lookbackValue: 14` and `lookbackUnit: day`. Verify 14 days of data is returned.
- [x] **Custom date range** — use `dateRange: customDateRange` with explicit `startDate` and `endDate`. Verify the returned data falls within that range.
- [x] **All chart types** — test each chart type: `line`, `area`, `timeseries-table`, `table`, `bar`, `stackedBar`, `horizontalBar`, `stackedHorizontalBar`, `bigNumber`. Verify each produces a valid response without errors.
- [x] **Timeseries chart auto-injects date dimension** — use a timeseries chart type (`line`, `area`, or `timeseries-table`) without specifying any dimensions. Verify the response includes date-bucketed rows (the `buildDimensions` function should auto-add the date dimension).
- [x] **Cumulative chart skips date dimension** — use a non-timeseries chart type (`bar`, `table`, `bigNumber`) without dimensions. Verify no date dimension is injected and the response returns cumulative data.
- [x] **Date granularity options** — test `dateGranularity` values: `auto`, `hour`, `day`, `week`, `month`, `year`. Verify the data granularity changes accordingly (or is auto-adjusted for large ranges).
- [x] **Dynamic dimension** — add a dimension with `dimensionType: dynamic`, a `column` name (e.g. `country`), and `maxValues: 5`. Verify the response includes a breakdown column and is limited to 5 values.
- [x] **Static dimension** — add a dimension with `dimensionType: static`, a `column`, and specific `values` (e.g. `['US', 'CA']`). Verify only those values appear in the results.
- [x] **Slice dimension** — add a dimension with `dimensionType: slice` and named slices with filters. Verify the response groups data into the named slices.
- [x] **Multiple dimensions** — combine a date dimension with a dynamic or static dimension. Verify the response has both date and breakdown columns in the table.
- [x] **Cache modes** — test `cache: preferred` (default), `cache: never`, and `cache: required`. Verify `never` forces a fresh query and `required` returns null or cached data only.
- [x] **Custom series name** — provide a `name` parameter. Verify the output uses that name instead of the metric's default name.
- [x] **Large result set (>30 rows)** — query a metric with daily granularity over 90+ days. Verify the formatter truncates at 30 rows and shows a `*(X more rows)*` message.
- [x] **Exploration URL** — verify every successful response includes a clickable `[View chart in GrowthBook](...)` link and that the link opens the correct exploration in the GrowthBook UI.
- [x] **Running/queued state** — if possible, trigger a long-running query (or use `cache: never` on a large dataset). Verify the tool returns a "still running" message with query status rather than an error.
- [x] **End-to-end agent workflow** — in a chat, ask the agent to "show me how my signup metric has been trending." Verify the agent calls `get_metrics` → picks the right metric → calls `create_metric_exploration` → presents the data to the user.

### Screenshots