### PR TITLE
Add Fact Table Exploration Tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `get_fact_table` tool — fetch a single fact table by id (columns, SQL, datasource, user id types) for analytics and metric configuration
+- `list_fact_tables` tool — list fact tables with pagination and optional project or data source filters; use ids for product analytics and fact metrics workflows
 - `create_metric_exploration` tool — chart metric data over time with configurable date ranges and chart types, returns visualization data and a link to view in GrowthBook
+
+### Changed
+
+- `get_fact_table` — column details are shown as per-column JSON (all keys returned by the API, including deleted columns). Tool description notes that omitted boolean fields on a column object should be read as false.
 
 ## [1.8.1] - 2026-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ All notable changes to this project will be documented in this file.
 - `get_fact_table` tool — fetch a single fact table by id (columns, SQL, datasource, user id types) for analytics and metric configuration
 - `list_fact_tables` tool — list fact tables with pagination and optional project or data source filters; use ids for product analytics and fact metrics workflows
 - `create_metric_exploration` tool — chart metric data over time with configurable date ranges and chart types, returns visualization data and a link to view in GrowthBook
+- `create_fact_table_exploration` tool — run product-analytics queries directly against a fact table (row count, unit count, sum of a column) with the same chart and date-range options as metric exploration
 
 ### Changed
 
 - `get_fact_table` — column details are shown as per-column JSON (all keys returned by the API, including deleted columns). Tool description notes that omitted boolean fields on a column object should be read as false.
+- `create_metric_exploration` — supports multiple fact metrics on one chart via optional `metrics[]` (same datasource required); single-series callers still use `metricId` and optional `name`. Tool and manifest descriptions updated.
+- `create_fact_table_exploration` — descriptions clarify that the `series` array can include multiple entries for one chart (tool, manifest, and Zod field description).
+
 
 ## [1.8.1] - 2026-03-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -110,7 +110,11 @@
     },
     {
       "name": "create_metric_exploration",
-      "description": "Chart an existing GrowthBook fact metric (IDs starting with 'fact__') over time. Legacy/standard metrics (IDs starting with 'met_') are not supported. Returns chart data and a link to view the visualization. If the query is still running, retry after 10-15 seconds."
+      "description": "Chart one or more GrowthBook fact metrics (IDs starting with 'fact__') on a single exploration: use metricId for one series, or metrics[] for multiple. All metrics in one call must share the same datasource. Legacy metrics (met_) are not supported. Returns chart data and a GrowthBook link; retry with cache preferred if still running. For custom multi-series aggregates on raw tables, use create_fact_table_exploration."
+    },
+    {
+      "name": "create_fact_table_exploration",
+      "description": "Chart data from a GrowthBook fact table. Requires factTableId and a series array (one or more entries: count, unit_count, or sum of a numeric column) so multiple series can appear on one chart. Use list_fact_tables and get_fact_table first. Returns exploration data and a GrowthBook chart link; same cache and date-range behavior as create_metric_exploration."
     }
   ],
   "prompts": [

--- a/manifest.json
+++ b/manifest.json
@@ -85,6 +85,14 @@
       "description": "List metrics in GrowthBook. Metrics measure experiment success. Includes both fact metrics (modern) and legacy metrics."
     },
     {
+      "name": "list_fact_tables",
+      "description": "List GrowthBook fact tables with optional filters by project or data source. Returns ids and datasource ids; use get_fact_table for full schema and SQL."
+    },
+    {
+      "name": "get_fact_table",
+      "description": "Fetch one fact table by id: datasource, user id types, full column objects as JSON (API keys only), and SQL. Omitted booleans on columns mean false. Use after list_fact_tables."
+    },
+    {
       "name": "get_defaults",
       "description": "Get default configuration and naming examples for creating experiments. Always call this before create_experiment."
     },

--- a/src/api-type-helpers.ts
+++ b/src/api-type-helpers.ts
@@ -80,6 +80,12 @@ export type ListFactMetricsResponse =
 export type GetFactMetricResponse =
   Paths["/fact-metrics/{id}"]["get"]["responses"][200]["content"]["application/json"];
 
+// Fact tables
+export type ListFactTablesResponse =
+  Paths["/fact-tables"]["get"]["responses"][200]["content"]["application/json"];
+export type GetFactTableResponse =
+  Paths["/fact-tables/{id}"]["get"]["responses"][200]["content"]["application/json"];
+
 // Stale features
 export type GetStaleFeatureResponse =
   Paths["/stale-features"]["get"]["responses"][200]["content"]["application/json"];

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -773,33 +773,53 @@ export function formatStaleFeatureFlags(
 }
 
 // ─── Product Analytics Explorations ─────────────────────────────────
-export function formatMetricExploration(
-  data: {
-    exploration: {
-      id: string;
-      status: "running" | "success" | "error";
-      dateStart: string;
-      dateEnd: string;
-      error?: string | null;
-      result: {
-        rows: {
-          dimensions: (string | null)[];
-          values: { metricId: string; numerator: number | null; denominator: number | null }[];
-        }[];
+
+/** Exploration API responses (metric, fact-table, data-source) share this shape */
+type ExplorationResultPayload = {
+  exploration: {
+    id: string;
+    status: "running" | "success" | "error";
+    dateStart: string;
+    dateEnd: string;
+    error?: string | null;
+    result: {
+      rows: {
+        dimensions: (string | null)[];
+        values: { metricId: string; numerator: number | null; denominator: number | null }[];
+      }[];
+    };
+    config?: {
+      dataset?: {
+        values?: { name?: string }[];
       };
-    } | null;
-    query: {
-      status: "running" | "queued" | "failed" | "partially-succeeded" | "succeeded";
-    } | null;
-    explorationUrl?: string;
-    message?: string;
-  },
-  metricName: string
+    };
+  } | null;
+  query: {
+    status: "running" | "queued" | "failed" | "partially-succeeded" | "succeeded";
+  } | null;
+  explorationUrl?: string;
+  message?: string;
+};
+
+function explorationValueColumnLabels(data: ExplorationResultPayload): string[] {
+  const values = data.exploration?.config?.dataset?.values;
+  if (Array.isArray(values) && values.length > 0) {
+    return values.map((v, i) =>
+      typeof v.name === "string" && v.name.length > 0 ? v.name : `Series ${i + 1}`
+    );
+  }
+  return ["Value"];
+}
+
+/** Formats metric, fact-table, or data-source exploration results for agents */
+export function formatExplorationResult(
+  data: ExplorationResultPayload,
+  title: string
 ): string {
   const parts: string[] = [];
 
   if (!data.exploration) {
-    parts.push(`**Metric exploration for ${metricName} could not be created.**`);
+    parts.push(`**Exploration for ${title} could not be created.**`);
     if (data.message) parts.push(data.message);
     if (data.query) parts.push(`Query status: ${data.query.status}`);
     return parts.join("\n");
@@ -808,20 +828,19 @@ export function formatMetricExploration(
   const { exploration } = data;
 
   if (exploration.status === "running") {
-    parts.push(`**Metric exploration for ${metricName} is still running.**`);
+    parts.push(`**Exploration for ${title} is still running.**`);
     parts.push(`Query status: ${data.query?.status || "unknown"}`);
     parts.push("The query has not completed yet. Try again shortly.");
     return parts.join("\n");
   }
 
   if (exploration.status === "error") {
-    parts.push(`**Metric exploration for ${metricName} failed.**`);
+    parts.push(`**Exploration for ${title} failed.**`);
     if (exploration.error) parts.push(`Error: ${exploration.error}`);
     return parts.join("\n");
   }
 
-  // Success
-  parts.push(`**Metric exploration: ${metricName}**`);
+  parts.push(`**Exploration: ${title}**`);
   parts.push(`Date range: ${exploration.dateStart} to ${exploration.dateEnd}`);
 
   const rows = exploration.result?.rows || [];
@@ -830,34 +849,43 @@ export function formatMetricExploration(
   if (rows.length > 0) {
     const dimCount = rows[0].dimensions.length;
     const hasBreakdown = dimCount > 1;
+    const valueLabels = explorationValueColumnLabels(data);
+    const nValues = Math.max(1, rows[0].values?.length ?? 0);
+    const valueHeads = Array.from({ length: nValues }, (_, i) => {
+      return valueLabels[i] ?? `Series ${i + 1}`;
+    });
+    const valueSep = Array(nValues).fill("-------").join("|");
 
     parts.push("");
 
     if (hasBreakdown) {
-      parts.push("| Date | Dimension | Value |");
-      parts.push("|------|-----------|-------|");
+      parts.push(`| Date | Dimension | ${valueHeads.join(" | ")} |`);
+      parts.push(`|------|-----------|${valueSep}|`);
     } else {
-      parts.push("| Date | Value |");
-      parts.push("|------|-------|");
+      parts.push(`| Date | ${valueHeads.join(" | ")} |`);
+      parts.push(`|------|${valueSep}|`);
     }
 
     const displayRows = rows.slice(0, 30);
     for (const row of displayRows) {
-      const date = row.dimensions[0] ?? "—";
-      const value = row.values[0]?.numerator;
-      const formatted = value != null ? value.toLocaleString() : "—";
+      const primary = row.dimensions[0] ?? "—";
+      const valueCells: string[] = [];
+      for (let i = 0; i < nValues; i++) {
+        const v = row.values[i]?.numerator;
+        valueCells.push(v != null ? v.toLocaleString() : "—");
+      }
 
       if (hasBreakdown) {
         const dimension = row.dimensions.slice(1).join(", ") || "—";
-        parts.push(`| ${date} | ${dimension} | ${formatted} |`);
+        parts.push(`| ${primary} | ${dimension} | ${valueCells.join(" | ")} |`);
       } else {
-        parts.push(`| ${date} | ${formatted} |`);
+        parts.push(`| ${primary} | ${valueCells.join(" | ")} |`);
       }
     }
 
     if (rows.length > 30) {
-      const cols = hasBreakdown ? "| ... | ... |" : "| ... |";
-      parts.push(`${cols} *(${rows.length - 30} more rows)* |`);
+      parts.push("");
+      parts.push(`*(${rows.length - 30} more rows not shown)*`);
     }
   }
 

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -16,6 +16,8 @@ import type {
   ListFactMetricsResponse,
   GetMetricResponse,
   GetFactMetricResponse,
+  ListFactTablesResponse,
+  GetFactTableResponse,
   Feature,
   GetStaleFeatureResponse,
 } from "./api-type-helpers.js";
@@ -57,6 +59,113 @@ export function formatProjects(data: ListProjectsResponse): string {
     "",
     `Use the \`id\` value when creating feature flags or experiments scoped to a project.`,
   ].join("\n");
+}
+
+// ─── Fact tables ────────────────────────────────────────────────────
+export function formatFactTablesList(data: ListFactTablesResponse): string {
+  const tables = data.factTables || [];
+  if (tables.length === 0) {
+    return "No fact tables found for the current filters.";
+  }
+
+  const lines = tables.map((t) => {
+    const parts = [
+      `- **${t.name}** (id: \`${t.id}\`, datasource: \`${t.datasource}\`)`,
+    ];
+    if (t.archived) parts.push("  *(archived)*");
+    if (t.description?.trim()) parts.push(`  ${t.description.trim()}`);
+    return parts.join("\n");
+  });
+
+  const total = data.total;
+  const header =
+    typeof total === "number"
+      ? `**${tables.length} fact table(s)** on this page (${total} total in organization):`
+      : `**${tables.length} fact table(s):**`;
+
+  return [
+    header,
+    "",
+    ...lines,
+    "",
+    "Use the `id` as `factTableId` when building fact-table explorations or fact metrics. Call `get_fact_table` with an id for full column definitions and SQL.",
+    data.hasMore
+      ? `More results available (nextOffset: ${data.nextOffset ?? "—"}). Increase \`offset\` to paginate.`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+const FACT_TABLE_SQL_MAX_CHARS = 4000;
+
+export function formatFactTableDetail(data: GetFactTableResponse): string {
+  const t = data.factTable;
+  if (!t) return "Fact table not found.";
+
+  const parts: string[] = [];
+  parts.push(`**Fact table: ${t.name}** (id: \`${t.id}\`)`);
+  parts.push(`Datasource: \`${t.datasource}\``);
+  if (t.archived) parts.push("*(archived)*");
+  if (t.description?.trim()) parts.push(`Description: ${t.description.trim()}`);
+  if (t.owner?.trim()) parts.push(`Owner: ${t.owner}`);
+  if (t.projects?.length)
+    parts.push(`Projects: ${t.projects.map((p) => `\`${p}\``).join(", ")}`);
+  if (t.tags?.length)
+    parts.push(`Tags: ${t.tags.map((x) => `\`${x}\``).join(", ")}`);
+  if (t.userIdTypes?.length)
+    parts.push(
+      `User id types: ${t.userIdTypes.map((x) => `\`${x}\``).join(", ")}`
+    );
+  if (t.eventName) parts.push(`Event name: \`${t.eventName}\``);
+  if (t.managedBy) parts.push(`Managed by: \`${t.managedBy}\``);
+  parts.push("");
+
+  if (t.columnsError?.trim()) {
+    parts.push(`**Column parse error:** ${t.columnsError.trim()}`);
+    parts.push("");
+  }
+
+  const cols = t.columns || [];
+  if (cols.length === 0) {
+    parts.push("**Columns:** *(none returned)*");
+  } else {
+    parts.push(
+      "**Columns** *(one JSON object per `factTable.columns[]` entry, API order; includes `deleted` columns. Only keys the API returns appear; omitted boolean fields on a column mean false per GrowthBook API.)*"
+    );
+    parts.push("");
+    for (const c of cols) {
+      const heading = c.name?.trim()
+        ? `\`${c.column}\` (${c.name.trim()})`
+        : `\`${c.column}\``;
+      parts.push(`### ${heading}`);
+      parts.push("");
+      parts.push("```json");
+      parts.push(JSON.stringify(c, null, 2));
+      parts.push("```");
+      parts.push("");
+    }
+  }
+
+  parts.push("");
+  parts.push("**SQL:**");
+  parts.push("");
+  const sql = t.sql || "";
+  if (sql.length <= FACT_TABLE_SQL_MAX_CHARS) {
+    parts.push("```sql");
+    parts.push(sql || "—");
+    parts.push("```");
+  } else {
+    parts.push("```sql");
+    parts.push(sql.slice(0, FACT_TABLE_SQL_MAX_CHARS));
+    parts.push("```");
+    parts.push("");
+    parts.push(
+      `*(SQL truncated; ${sql.length - FACT_TABLE_SQL_MAX_CHARS} more characters in source.)*`
+    );
+  }
+
+  return parts.join("\n");
 }
 
 // ─── Environments ───────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ Key workflows:
 - Feature flags: Use create_feature_flag for simple flags, then create_force_rule to add targeting conditions
 - Experiments: ALWAYS call get_defaults first, then create_experiment. Experiments are created as "draft" - users must launch in GrowthBook UI
 - Analysis: Use get_experiments with mode="summary" for quick insights
-- Product analytics: Use list_fact_tables to find fact table IDs, then get_fact_table for columns and SQL. Use get_metrics to find fact metric IDs. Use create_metric_exploration to chart fact metric data.
+- Product analytics: Use list_fact_tables to find fact table IDs, then get_fact_table for columns and SQL. Use get_metrics to find fact metric IDs. Use create_metric_exploration to chart one or more fact metrics on the same exploration (metricId or metrics[]), or create_fact_table_exploration for ad-hoc aggregates with one or more series (counts, distinct units, sums).
 
 All mutating tools require a fileExtension parameter for SDK integration guidance.`,
     capabilities: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { getApiKey, getApiUrl, getAppOrigin } from "./utils.js";
 import { registerSearchTools } from "./tools/search.js";
 import { registerDefaultsTools } from "./tools/defaults.js";
 import { registerMetricsTools } from "./tools/metrics.js";
+import { registerFactTableTools } from "./tools/fact-tables.js";
 import { registerProductAnalyticsTools } from "./tools/product-analytics.js";
 import { registerExperimentPrompts } from "./prompts/experiment-prompts.js";
 import packageDetails from "../package.json" with { type: "json" };
@@ -39,7 +40,7 @@ Key workflows:
 - Feature flags: Use create_feature_flag for simple flags, then create_force_rule to add targeting conditions
 - Experiments: ALWAYS call get_defaults first, then create_experiment. Experiments are created as "draft" - users must launch in GrowthBook UI
 - Analysis: Use get_experiments with mode="summary" for quick insights
-- Product analytics: Use create_metric_exploration to chart metric data. Use get_metrics first to find the metric ID.
+- Product analytics: Use list_fact_tables to find fact table IDs, then get_fact_table for columns and SQL. Use get_metrics to find fact metric IDs. Use create_metric_exploration to chart fact metric data.
 
 All mutating tools require a fileExtension parameter for SDK integration guidance.`,
     capabilities: {
@@ -99,6 +100,12 @@ registerMetricsTools({
   apiKey,
   appOrigin,
   user,
+});
+
+registerFactTableTools({
+  server,
+  baseApiUrl,
+  apiKey,
 });
 
 registerProductAnalyticsTools({

--- a/src/tools/exploration-schemas.ts
+++ b/src/tools/exploration-schemas.ts
@@ -1,0 +1,278 @@
+import { z } from "zod";
+
+/** Row filter operators accepted by product-analytics exploration APIs */
+export const explorationFilterOperatorSchema = z.enum([
+  "=",
+  "!=",
+  "<",
+  "<=",
+  ">",
+  ">=",
+  "in",
+  "not_in",
+  "contains",
+  "not_contains",
+  "starts_with",
+  "ends_with",
+  "is_null",
+  "not_null",
+  "is_true",
+  "is_false",
+  "sql_expr",
+  "saved_filter",
+]);
+
+export const explorationRowFilterSchema = z.object({
+  operator: explorationFilterOperatorSchema,
+  column: z.string().optional(),
+  values: z.array(z.string()).optional(),
+});
+
+export const explorationDimensionSchema = z.discriminatedUnion("dimensionType", [
+  z.object({
+    dimensionType: z.literal("date"),
+    column: z
+      .string()
+      .default("date")
+      .describe("Date column name."),
+    dateGranularity: z
+      .enum(["auto", "hour", "day", "week", "month", "year"])
+      .describe("Granularity for the date axis."),
+  }),
+  z.object({
+    dimensionType: z.literal("dynamic"),
+    column: z
+      .string()
+      .describe(
+        "Column name to group by (e.g. 'country', 'device_type'). Shows the top N values."
+      ),
+    maxValues: z
+      .number()
+      .default(10)
+      .describe("Maximum number of distinct values to return."),
+  }),
+  z.object({
+    dimensionType: z.literal("static"),
+    column: z
+      .string()
+      .describe("Column name to group by (e.g. 'country')."),
+    values: z
+      .array(z.string())
+      .describe(
+        "Specific values to include (e.g. ['US', 'CA', 'UK']). Only these values will appear in the results."
+      ),
+  }),
+  z.object({
+    dimensionType: z.literal("slice"),
+    slices: z
+      .array(
+        z.object({
+          name: z
+            .string()
+            .describe(
+              "Display name for this slice (e.g. 'North America', 'Mobile users')."
+            ),
+          filters: z
+            .array(explorationRowFilterSchema)
+            .describe("Filters that define this slice."),
+        })
+      )
+      .describe(
+        "Named slices, each defined by a set of filters. Use for custom groupings like 'North America' = country in ['US','CA']."
+      ),
+  }),
+]);
+
+const dimensionsField = z
+  .array(explorationDimensionSchema)
+  .optional()
+  .describe(
+    "Dimensions to break down the data. For timeseries charts (line, area, timeseries-table), a date dimension is auto-included if not explicitly provided. For cumulative charts (bar, table, bigNumber), omit the date dimension. " +
+      "Types: 'date' for time axis, 'dynamic' for top-N grouping, 'static' for specific values, 'slice' for custom named segments. " +
+      "Prefer 'dynamic' over 'static' for group-by dimensions — 'static' and 'slice' dimensions work in the API response but are not yet fully supported in the GrowthBook UI chart view. Use 'dynamic' for results that render correctly in both the API and the GrowthBook link."
+  );
+
+/** Shared Zod fields for metric and fact-table exploration tools */
+export const explorationSharedInputSchema = z.object({
+  dateRange: z
+    .enum([
+      "today",
+      "last7Days",
+      "last30Days",
+      "last90Days",
+      "customLookback",
+      "customDateRange",
+    ])
+    .default("last30Days")
+    .describe(
+      "Date range for the chart. Use a predefined range, 'customLookback' with lookbackValue/lookbackUnit, or 'customDateRange' with startDate/endDate."
+    ),
+  lookbackValue: z
+    .number()
+    .optional()
+    .describe(
+      "Number of time units to look back. Only used when dateRange is 'customLookback'. Example: 14 with lookbackUnit 'day' = last 14 days."
+    ),
+  lookbackUnit: z
+    .enum(["hour", "day", "week", "month"])
+    .optional()
+    .describe(
+      "Time unit for the lookback. Only used when dateRange is 'customLookback'."
+    ),
+  startDate: z
+    .string()
+    .optional()
+    .describe(
+      "Start date for custom date range (ISO 8601 format, e.g. '2025-01-01'). Only used when dateRange is 'customDateRange'."
+    ),
+  endDate: z
+    .string()
+    .optional()
+    .describe(
+      "End date for custom date range (ISO 8601 format, e.g. '2025-03-31'). Only used when dateRange is 'customDateRange'."
+    ),
+  cache: z
+    .enum(["preferred", "required", "never"])
+    .default("preferred")
+    .describe(
+      "Cache behavior: 'preferred' (default) returns cached results if available, otherwise runs a new query; 'never' always runs a fresh query; 'required' only returns cached results or null if none exist."
+    ),
+  chartType: z
+    .enum([
+      "line",
+      "area",
+      "timeseries-table",
+      "table",
+      "bar",
+      "stackedBar",
+      "horizontalBar",
+      "stackedHorizontalBar",
+      "bigNumber",
+    ])
+    .default("line")
+    .describe(
+      "The type of chart to render. Chart mode vs time series: line, area, and timeseries-table charts are always timeseries — these must include a date dimension. Bar charts (bar, stackedBar, horizontalBar, stackedHorizontalBar), the plain table chart, and bigNumber are cumulative — these do not use a date dimension. When switching between timeseries and cumulative chart types, add or remove the date dimension accordingly."
+    ),
+  dateGranularity: z
+    .enum(["auto", "hour", "day", "week", "month", "year"])
+    .default("auto")
+    .describe(
+      "Granularity for the date dimension. Depending on the amount of time scanned, the granularity might be automatically adjusted to a less granular level to reduce the number of data points."
+    ),
+  dimensions: dimensionsField,
+});
+
+export type ExplorationSharedInput = z.infer<typeof explorationSharedInputSchema>;
+
+export function buildDateRangePayload(
+  dateRange: ExplorationSharedInput["dateRange"],
+  lookbackValue: number | undefined,
+  lookbackUnit: ExplorationSharedInput["lookbackUnit"],
+  startDate: string | undefined,
+  endDate: string | undefined
+) {
+  return {
+    predefined: dateRange,
+    lookbackValue: dateRange === "customLookback" ? lookbackValue ?? null : null,
+    lookbackUnit: dateRange === "customLookback" ? lookbackUnit ?? null : null,
+    startDate: dateRange === "customDateRange" ? startDate ?? null : null,
+    endDate: dateRange === "customDateRange" ? endDate ?? null : null,
+  };
+}
+
+export const TIMESERIES_CHART_TYPES = new Set(["line", "area", "timeseries-table"]);
+
+export function buildDimensions(
+  dimensions: Array<Record<string, unknown>> | undefined,
+  chartType: string,
+  dateGranularity: string
+): Array<Record<string, unknown>> {
+  const dims = (dimensions || []).map((d) => {
+    if (d.dimensionType === "date" && !d.column) {
+      return { ...d, column: "date" };
+    }
+    return d;
+  });
+  const hasDateDimension = dims.some((d) => d.dimensionType === "date");
+
+  if (!hasDateDimension && TIMESERIES_CHART_TYPES.has(chartType)) {
+    return [
+      { dimensionType: "date", column: "date", dateGranularity },
+      ...dims,
+    ];
+  }
+
+  return dims;
+}
+
+/** One series for fact-table exploration `dataset.values[]` */
+export const factTableExplorationSeriesSchema = z.discriminatedUnion(
+  "valueType",
+  [
+    z.object({
+      name: z
+        .string()
+        .describe("Legend label for this series in the chart and API results."),
+      valueType: z.literal("count"),
+      unit: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Optional unit label (e.g. currency) for display."),
+      rowFilters: z
+        .array(explorationRowFilterSchema)
+        .default([])
+        .describe("Filters applied to fact-table rows before aggregating."),
+    }),
+    z.object({
+      name: z.string().describe("Legend label for this series."),
+      valueType: z.literal("unit_count"),
+      unit: z.string().nullable().optional(),
+      rowFilters: z.array(explorationRowFilterSchema).default([]),
+    }),
+    z.object({
+      name: z.string().describe("Legend label for this series."),
+      valueType: z.literal("sum"),
+      valueColumn: z
+        .string()
+        .min(1)
+        .describe(
+          "Numeric fact-table column to sum (use get_fact_table to list valid column names)."
+        ),
+      unit: z.string().nullable().optional(),
+      rowFilters: z.array(explorationRowFilterSchema).default([]),
+    }),
+  ]
+);
+
+export type FactTableExplorationSeries = z.infer<
+  typeof factTableExplorationSeriesSchema
+>;
+
+/** One fact metric series for metric exploration `dataset.values[]` */
+export const metricExplorationEntrySchema = z.object({
+  metricId: z
+    .string()
+    .describe(
+      "The ID of a fact metric to chart (must start with 'fact__'). Use get_metrics to discover ids."
+    ),
+  name: z
+    .string()
+    .optional()
+    .describe(
+      "Legend label for this series in the chart and formatted table. Defaults to the metric's name from GrowthBook."
+    ),
+});
+
+export type MetricExplorationEntry = z.infer<typeof metricExplorationEntrySchema>;
+
+export function mapFactTableSeriesToPayload(series: FactTableExplorationSeries) {
+  return {
+    name: series.name,
+    type: "fact_table" as const,
+    valueType: series.valueType,
+    valueColumn: series.valueType === "sum" ? series.valueColumn : null,
+    unit: series.unit ?? null,
+    rowFilters: series.rowFilters,
+  };
+}

--- a/src/tools/fact-tables.ts
+++ b/src/tools/fact-tables.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import {
+  type BaseToolsInterface,
+  fetchWithPagination,
+  fetchWithRateLimit,
+  buildHeaders,
+  handleResNotOk,
+  paginationSchema,
+} from "../utils.js";
+import type {
+  ListFactTablesResponse,
+  GetFactTableResponse,
+} from "../api-type-helpers.js";
+import {
+  formatFactTablesList,
+  formatFactTableDetail,
+  formatApiError,
+} from "../format-responses.js";
+
+interface FactTableTools extends BaseToolsInterface {}
+
+export function registerFactTableTools({
+  server,
+  baseApiUrl,
+  apiKey,
+}: FactTableTools) {
+  server.registerTool(
+    "list_fact_tables",
+    {
+      title: "List Fact Tables",
+      description:
+        "Lists GrowthBook fact tables (event-level data sources for fact metrics and product analytics). " +
+        "Returns each table's id, name, and datasource id. Use `get_fact_table` with an id for full column objects (JSON per column), SQL, and user id types. " +
+        "Use `get_projects` to resolve project names when filtering by projectId. " +
+        "Use this to discover fact table IDs before charting or analysis tools that require a factTableId.",
+      inputSchema: z.object({
+        projectId: z
+          .string()
+          .optional()
+          .describe("Filter fact tables associated with this project id."),
+        datasourceId: z
+          .string()
+          .optional()
+          .describe("Filter fact tables that use this data source id."),
+        ...paginationSchema,
+      }),
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    async ({ limit, offset, mostRecent, projectId, datasourceId }) => {
+      try {
+        const additionalParams: Record<string, string> = {};
+        if (projectId) additionalParams.projectId = projectId;
+        if (datasourceId) additionalParams.datasourceId = datasourceId;
+
+        const data = (await fetchWithPagination(
+          baseApiUrl,
+          apiKey,
+          "/api/v1/fact-tables",
+          limit,
+          offset,
+          mostRecent,
+          Object.keys(additionalParams).length > 0
+            ? additionalParams
+            : undefined
+        )) as ListFactTablesResponse;
+
+        if (
+          mostRecent &&
+          offset === 0 &&
+          Array.isArray(data.factTables) &&
+          data.factTables.length > 0
+        ) {
+          data.factTables = [...data.factTables].reverse();
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatFactTablesList(data),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(error, "listing fact tables", [
+            "Check that your GB_API_KEY has permission to read fact tables.",
+            "Use get_projects if you need valid project IDs for filtering.",
+          ])
+        );
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_fact_table",
+    {
+      title: "Get Fact Table",
+      description:
+        "Fetches a single GrowthBook fact table by id (use `list_fact_tables` to discover ids). " +
+        "Returns datasource, user id types, metadata, SQL, and each `columns[]` entry as pretty-printed JSON (all keys the API returns, including slice-related fields and deleted columns). " +
+        "If a boolean property on a column object is omitted from that JSON, treat it as false. " +
+        "Use when configuring fact-table explorations, interpreting fact metrics, or validating column names for filters. " +
+        "Fact tables with `managedBy` set to `api` or `admin` are managed/official definitions.",
+      inputSchema: z.object({
+        factTableId: z
+          .string()
+          .describe(
+            "The fact table id (e.g. from list_fact_tables, typically prefixed with ftb_)."
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    async ({ factTableId }) => {
+      try {
+        const res = await fetchWithRateLimit(
+          `${baseApiUrl}/api/v1/fact-tables/${encodeURIComponent(factTableId)}`,
+          { headers: buildHeaders(apiKey) }
+        );
+        await handleResNotOk(res);
+        const data = (await res.json()) as GetFactTableResponse;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatFactTableDetail(data),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(error, `fetching fact table '${factTableId}'`, [
+            "Check the fact table id — use list_fact_tables to list valid ids.",
+            "Ensure your GB_API_KEY can read fact tables.",
+          ])
+        );
+      }
+    }
+  );
+}

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -5,11 +5,20 @@ import {
   fetchWithRateLimit,
   buildHeaders,
 } from "../utils.js";
-import type { CreateExplorationResponse } from "../api-type-helpers.js";
+import type {
+  CreateExplorationResponse,
+  CreateFactTableExplorationResponse,
+  GetFactTableResponse,
+} from "../api-type-helpers.js";
+import { formatExplorationResult, formatApiError } from "../format-responses.js";
 import {
-  formatMetricExploration,
-  formatApiError,
-} from "../format-responses.js";
+  explorationSharedInputSchema,
+  buildDateRangePayload,
+  buildDimensions,
+  factTableExplorationSeriesSchema,
+  mapFactTableSeriesToPayload,
+  metricExplorationEntrySchema,
+} from "./exploration-schemas.js";
 
 interface ProductAnalyticsTools extends BaseToolsInterface {
   appOrigin: string;
@@ -48,36 +57,97 @@ async function resolveFactMetricDatasource(
   return { datasource, metricName };
 }
 
-const TIMESERIES_CHART_TYPES = new Set(["line", "area", "timeseries-table"]);
+async function resolveFactTableDatasource(
+  baseApiUrl: string,
+  apiKey: string,
+  factTableId: string
+): Promise<{ datasource: string; factTableName: string }> {
+  const res = await fetchWithRateLimit(
+    `${baseApiUrl}/api/v1/fact-tables/${encodeURIComponent(factTableId)}`,
+    { headers: buildHeaders(apiKey) }
+  );
+  await handleResNotOk(res);
+  const data = (await res.json()) as GetFactTableResponse;
+  const ft = data.factTable;
+  const datasource = ft?.datasource;
+  const factTableName = ft?.name || factTableId;
 
-function buildDimensions(
-  dimensions: Array<Record<string, unknown>> | undefined,
-  chartType: string,
-  dateGranularity: string
-): Array<Record<string, unknown>> {
-  const dims = (dimensions || []).map((d) => {
-    if (d.dimensionType === "date" && !d.column) {
-      return { ...d, column: "date" };
-    }
-    return d;
-  });
-  const hasDateDimension = dims.some((d) => d.dimensionType === "date");
-
-  if (!hasDateDimension && TIMESERIES_CHART_TYPES.has(chartType)) {
-    return [
-      { dimensionType: "date", column: "date", dateGranularity },
-      ...dims,
-    ];
+  if (!datasource) {
+    throw new Error(
+      `Fact table '${factTableId}' does not have a datasource configured.`
+    );
   }
 
-  return dims;
+  return { datasource, factTableName };
 }
+
+const metricExplorationInputSchema = explorationSharedInputSchema
+  .extend({
+    metricId: z
+      .string()
+      .optional()
+      .describe(
+        "Single-series mode: the fact metric id to chart (must start with 'fact__'). Legacy/standard metrics (met_) are not supported. " +
+          "Use get_metrics to find ids. Omit when using metrics[] for multiple series on one chart."
+      ),
+    name: z
+      .string()
+      .optional()
+      .describe(
+        "Single-series mode only: display name for the series in the legend and formatted table. Defaults to the metric name from GrowthBook."
+      ),
+    metrics: z
+      .array(metricExplorationEntrySchema)
+      .optional()
+      .describe(
+        "Multi-series mode: one or more fact metrics on the same chart (same date range, chart type, and dimensions). " +
+          "Each entry is a fact__ metric id and optional legend name. All metrics must use the same datasource. " +
+          "Do not pass metricId/name when using this array."
+      ),
+  })
+  .superRefine((data, ctx) => {
+    const hasMulti = (data.metrics?.length ?? 0) > 0;
+    const hasSingle = Boolean(data.metricId?.trim());
+    if (hasMulti && hasSingle) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Use either metricId (single series) or metrics[] (one or more series), not both.",
+        path: ["metrics"],
+      });
+    }
+    if (!hasMulti && !hasSingle) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Provide metricId for one fact metric, or metrics[] with at least one fact metric.",
+        path: ["metricId"],
+      });
+    }
+  });
+
+const factTableExplorationInputSchema = explorationSharedInputSchema.extend({
+  factTableId: z
+    .string()
+    .describe(
+      "The fact table id (from list_fact_tables, typically prefixed with ftb_). Use get_fact_table first to confirm datasource columns for filters, sums, and dimensions."
+    ),
+  series: z
+    .array(factTableExplorationSeriesSchema)
+    .min(1)
+    .describe(
+      "One or more series for a single chart from the fact table (row counts, distinct unit counts, or sums of a numeric column). " +
+        "Pass multiple objects here to plot several measures at once (e.g. order count and sum of revenue). " +
+        "For valueType 'sum', valueColumn must be a numeric column name from get_fact_table. " +
+        "The formatted summary table lists each series in separate columns; the GrowthBook link shows the full chart."
+    ),
+});
 
 export function registerProductAnalyticsTools({
   server,
   baseApiUrl,
   apiKey,
-  appOrigin,
+  appOrigin: _appOrigin,
 }: ProductAnalyticsTools) {
   server.registerTool(
     "create_metric_exploration",
@@ -85,233 +155,82 @@ export function registerProductAnalyticsTools({
       title: "Create Metric Exploration",
       description:
         "This tool can be used to answer questions about Fact Metrics in GrowthBook. " +
-        "Charts an existing GrowthBook fact metric (IDs starting with 'fact__'), either as a time series or a cumulative chart. " +
-        "Legacy/standard metrics (IDs starting with 'met_') are NOT supported and will return an error — only fact metrics can be charted. " +
-        "Use `get_metrics` to find a fact metric ID. If the user references a metric by name, match it to a fact metric. This tool does not support legacy metrics. " +
-        "Returns chart data and a link to view the visualization in GrowthBook. " +
+        "Charts one or more GrowthBook fact metrics (IDs starting with 'fact__') on a single exploration — pass metricId for one series, or metrics[] for multiple series (e.g. compare metrics on the same time range). " +
+        "All metrics in one call must share the same datasource. Legacy/standard metrics (met_) are NOT supported. " +
+        "Use `get_metrics` to find fact metric IDs. Returns chart data and a link to view the visualization in GrowthBook. " +
         "The underlying query may take time to execute. If the response indicates the query is still running, wait 10–15 seconds and retry with cache 'preferred' to pick up the completed result. " +
-        "If no fact metric matches what the user wants to chart, consider using `create_fact_table_exploration` or `create_data_source_exploration` instead (when available).",
-      inputSchema: z.object({
-        metricId: z
-          .string()
-          .describe(
-            "The ID of the fact metric to chart (must start with 'fact__'). Legacy/standard metrics (IDs starting with 'met_') are not supported. " +
-              "Use get_metrics to find available metrics, then match the user's intent to the closest fact metric by name. " +
-              "If no fact metric matches but a legacy metric does, inform the user that only fact metrics can be charted."
-          ),
-        dateRange: z
-          .enum([
-            "today",
-            "last7Days",
-            "last30Days",
-            "last90Days",
-            "customLookback",
-            "customDateRange",
-          ])
-          .default("last30Days")
-          .describe(
-            "Date range for the chart. Use a predefined range, 'customLookback' with lookbackValue/lookbackUnit, or 'customDateRange' with startDate/endDate."
-          ),
-        lookbackValue: z
-          .number()
-          .optional()
-          .describe(
-            "Number of time units to look back. Only used when dateRange is 'customLookback'. Example: 14 with lookbackUnit 'day' = last 14 days."
-          ),
-        lookbackUnit: z
-          .enum(["hour", "day", "week", "month"])
-          .optional()
-          .describe(
-            "Time unit for the lookback. Only used when dateRange is 'customLookback'."
-          ),
-        startDate: z
-          .string()
-          .optional()
-          .describe(
-            "Start date for custom date range (ISO 8601 format, e.g. '2025-01-01'). Only used when dateRange is 'customDateRange'."
-          ),
-        endDate: z
-          .string()
-          .optional()
-          .describe(
-            "End date for custom date range (ISO 8601 format, e.g. '2025-03-31'). Only used when dateRange is 'customDateRange'."
-          ),
-        cache: z
-          .enum(["preferred", "required", "never"])
-          .default("preferred")
-          .describe(
-            "Cache behavior: 'preferred' (default) returns cached results if available, otherwise runs a new query; 'never' always runs a fresh query; 'required' only returns cached results or null if none exist."
-          ),
-        chartType: z
-          .enum([
-            "line",
-            "area",
-            "timeseries-table",
-            "table",
-            "bar",
-            "stackedBar",
-            "horizontalBar",
-            "stackedHorizontalBar",
-            "bigNumber",
-          ])
-          .default("line")
-          .describe(
-            "The type of chart to render. Chart mode vs time series: line, area, and timeseries-table charts are always timeseries — these must include a date dimension. Bar charts (bar, stackedBar, horizontalBar, stackedHorizontalBar), the plain table chart, and bigNumber are cumulative — thesedo not use a date dimension. When switching between timeseries and cumulative chart types, add or remove the date dimension accordingly"
-          ),
-        dateGranularity: z
-          .enum(["auto", "hour", "day", "week", "month", "year"])
-          .default("auto")
-          .describe(
-            "Granularity for the date dimension. Depending on the amount of time scanned, the granularity might be automatically adjusted to a less granular level to reduce the number of data points."
-          ),
-        dimensions: z
-          .array(
-            z.discriminatedUnion("dimensionType", [
-              z.object({
-                dimensionType: z.literal("date"),
-                column: z
-                  .string()
-                  .default("date")
-                  .describe("Date column name."),
-                dateGranularity: z
-                  .enum(["auto", "hour", "day", "week", "month", "year"])
-                  .describe("Granularity for the date axis."),
-              }),
-              z.object({
-                dimensionType: z.literal("dynamic"),
-                column: z
-                  .string()
-                  .describe(
-                    "Column name to group by (e.g. 'country', 'device_type'). Shows the top N values."
-                  ),
-                maxValues: z
-                  .number()
-                  .default(10)
-                  .describe("Maximum number of distinct values to return."),
-              }),
-              z.object({
-                dimensionType: z.literal("static"),
-                column: z
-                  .string()
-                  .describe("Column name to group by (e.g. 'country')."),
-                values: z
-                  .array(z.string())
-                  .describe(
-                    "Specific values to include (e.g. ['US', 'CA', 'UK']). Only these values will appear in the results."
-                  ),
-              }),
-              z.object({
-                dimensionType: z.literal("slice"),
-                slices: z
-                  .array(
-                    z.object({
-                      name: z
-                        .string()
-                        .describe(
-                          "Display name for this slice (e.g. 'North America', 'Mobile users')."
-                        ),
-                      filters: z
-                        .array(
-                          z.object({
-                            operator: z.enum([
-                              "=",
-                              "!=",
-                              "<",
-                              "<=",
-                              ">",
-                              ">=",
-                              "in",
-                              "not_in",
-                              "contains",
-                              "not_contains",
-                              "starts_with",
-                              "ends_with",
-                              "is_null",
-                              "not_null",
-                              "is_true",
-                              "is_false",
-                              "sql_expr",
-                              "saved_filter",
-                            ]),
-                            column: z.string().optional(),
-                            values: z.array(z.string()).optional(),
-                          })
-                        )
-                        .describe("Filters that define this slice."),
-                    })
-                  )
-                  .describe(
-                    "Named slices, each defined by a set of filters. Use for custom groupings like 'North America' = country in ['US','CA']."
-                  ),
-              }),
-            ])
-          )
-          .optional()
-          .describe(
-            "Dimensions to break down the data. For timeseries charts (line, area, timeseries-table), a date dimension is auto-included if not explicitly provided. For cumulative charts (bar, table, bigNumber), omit the date dimension. " +
-              "Types: 'date' for time axis, 'dynamic' for top-N grouping, 'static' for specific values, 'slice' for custom named segments. " +
-              "Prefer 'dynamic' over 'static' for group-by dimensions — 'static' and 'slice' dimensions work in the API response but are not yet fully supported in the GrowthBook UI chart view. Use 'dynamic' for results that render correctly in both the API and the GrowthBook link."
-          ),
-        name: z
-          .string()
-          .optional()
-          .describe(
-            "Display name for the metric series in the chart legend and GrowthBook UI. Defaults to the metric name. Use this to give the chart a custom title when the user requests one."
-          ),
-      }),
+        "For ad-hoc aggregates on raw fact tables (counts, sums, multiple custom series), use `create_fact_table_exploration` with a series array; use `create_data_source_exploration` when that tool is available.",
+      inputSchema: metricExplorationInputSchema,
       annotations: {
         readOnlyHint: false,
       },
     },
-    async ({
-      metricId,
-      dateRange,
-      lookbackValue,
-      lookbackUnit,
-      startDate,
-      endDate,
-      cache,
-      chartType,
-      dateGranularity,
-      dimensions,
-      name,
-    }) => {
+    async (input) => {
+      const {
+        metricId,
+        name,
+        metrics,
+        dateRange,
+        lookbackValue,
+        lookbackUnit,
+        startDate,
+        endDate,
+        cache,
+        chartType,
+        dateGranularity,
+        dimensions,
+      } = input;
+
+      const metricEntries =
+        metrics && metrics.length > 0
+          ? metrics
+          : [{ metricId: metricId as string, name }];
+
       try {
-        const { datasource, metricName } = await resolveFactMetricDatasource(
-          baseApiUrl,
-          apiKey,
-          metricId
+        const resolved = await Promise.all(
+          metricEntries.map((m) =>
+            resolveFactMetricDatasource(baseApiUrl, apiKey, m.metricId)
+          )
         );
 
-        const seriesName = name || metricName;
+        const explorationLabel =
+          metricEntries.length > 1
+            ? `${metricEntries.length} fact metrics`
+            : metricEntries[0].name ?? resolved[0].metricName;
+
+        const datasource = resolved[0].datasource;
+        for (let i = 1; i < resolved.length; i++) {
+          if (resolved[i].datasource !== datasource) {
+            throw new Error(
+              `All metrics must use the same datasource. ` +
+                `'${metricEntries[i].metricId}' uses '${resolved[i].datasource}', ` +
+                `but '${metricEntries[0].metricId}' uses '${datasource}'.`
+            );
+          }
+        }
 
         const payload = {
           datasource,
           type: "metric" as const,
           chartType,
-          dateRange: {
-            predefined: dateRange,
-            lookbackValue:
-              dateRange === "customLookback" ? lookbackValue ?? null : null,
-            lookbackUnit:
-              dateRange === "customLookback" ? lookbackUnit ?? null : null,
-            startDate:
-              dateRange === "customDateRange" ? startDate ?? null : null,
-            endDate: dateRange === "customDateRange" ? endDate ?? null : null,
-          },
+          dateRange: buildDateRangePayload(
+            dateRange,
+            lookbackValue,
+            lookbackUnit,
+            startDate,
+            endDate
+          ),
           dimensions: buildDimensions(dimensions, chartType, dateGranularity),
           dataset: {
             type: "metric" as const,
-            values: [
-              {
-                name: seriesName,
-                type: "metric" as const,
-                metricId,
-                rowFilters: [],
-                unit: null,
-                denominatorUnit: null,
-              },
-            ],
+            values: metricEntries.map((m, i) => ({
+              name: m.name ?? resolved[i].metricName,
+              type: "metric" as const,
+              metricId: m.metricId,
+              rowFilters: [],
+              unit: null,
+              denominatorUnit: null,
+            })),
           },
         };
 
@@ -334,7 +253,110 @@ export function registerProductAnalyticsTools({
           content: [
             {
               type: "text" as const,
-              text: formatMetricExploration(data, seriesName),
+              text: formatExplorationResult(data, explorationLabel),
+            },
+          ],
+        };
+      } catch (error) {
+        const ids = metricEntries.map((m) => m.metricId).join(", ");
+        throw new Error(
+          formatApiError(
+            error,
+            `creating metric exploration for '${ids}'`,
+            [
+              "Only fact metrics are supported — IDs must start with 'fact__'.",
+              "Use get_metrics to find available fact metric IDs.",
+              "Multiple metrics in one chart must share the same datasource.",
+              "If no fact metric matches, use create_fact_table_exploration or create_data_source_exploration instead.",
+            ]
+          )
+        );
+      }
+    }
+  );
+
+  server.registerTool(
+    "create_fact_table_exploration",
+    {
+      title: "Create Fact Table Exploration",
+      description:
+        "Requires a factTableId and a series array with at least one entry; you can pass multiple series in one call (e.g. row count and sum of amount on the same chart). " +
+        "Runs a GrowthBook product-analytics query against a fact table (raw event-level SQL source), returning chart data and optionally a link to the visualization. " +
+        "Each series can be row count, distinct unit count, or sum of a numeric column (use get_fact_table for column names). " +
+        "For saved definitions and reuse, prefer fact metrics and `create_metric_exploration` (multiple fact metrics per chart). " +
+        "Use list_fact_tables to discover ids, then get_fact_table for column names, SQL, and filters before calling this tool. " +
+        "The query may take time; if the response says it is still running, wait 10–15 seconds and retry with cache 'preferred'.",
+      inputSchema: factTableExplorationInputSchema,
+      annotations: {
+        readOnlyHint: false,
+      },
+    },
+    async (input) => {
+      const {
+        factTableId,
+        series,
+        dateRange,
+        lookbackValue,
+        lookbackUnit,
+        startDate,
+        endDate,
+        cache,
+        chartType,
+        dateGranularity,
+        dimensions,
+      } = input;
+
+      try {
+        const { datasource, factTableName } = await resolveFactTableDatasource(
+          baseApiUrl,
+          apiKey,
+          factTableId
+        );
+
+        const payload = {
+          datasource,
+          type: "fact_table" as const,
+          chartType,
+          dateRange: buildDateRangePayload(
+            dateRange,
+            lookbackValue,
+            lookbackUnit,
+            startDate,
+            endDate
+          ),
+          dimensions: buildDimensions(dimensions, chartType, dateGranularity),
+          dataset: {
+            type: "fact_table" as const,
+            factTableId,
+            values: series.map(mapFactTableSeriesToPayload),
+          },
+        };
+
+        const res = await fetchWithRateLimit(
+          `${baseApiUrl}/api/v1/product-analytics/fact-table-exploration?cache=${cache}`,
+          {
+            method: "POST",
+            headers: buildHeaders(apiKey),
+            body: JSON.stringify(payload),
+          }
+        );
+
+        await handleResNotOk(res);
+
+        const data = (await res.json()) as CreateFactTableExplorationResponse & {
+          explorationUrl?: string;
+        };
+
+        const title =
+          series.length > 1
+            ? `${factTableName} (${series.length} series)`
+            : factTableName;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatExplorationResult(data, title),
             },
           ],
         };
@@ -342,11 +364,11 @@ export function registerProductAnalyticsTools({
         throw new Error(
           formatApiError(
             error,
-            `creating metric exploration for '${metricId}'`,
+            `creating fact table exploration for '${factTableId}'`,
             [
-              "Only fact metrics are supported — IDs must start with 'fact__'.",
-              "Use get_metrics to find available fact metric IDs.",
-              "If no fact metric matches, consider charting from a fact table or data source instead.",
+              "Verify factTableId with list_fact_tables and get_fact_table.",
+              "For sum series, valueColumn must be a numeric column on that fact table.",
+              "Ensure your API key can read fact tables and run product analytics queries.",
             ]
           )
         );


### PR DESCRIPTION
### Features and Changes

Adds product analytics exploration tooling to the GrowthBook MCP server, enabling agents to chart metrics and run ad-hoc aggregates against fact tables directly from a conversation.

**New tools:**
- `list_fact_tables` — lists GrowthBook fact tables with their IDs, names, and datasource IDs; supports filtering by project or datasource, and pagination
- `get_fact_table` — fetches a single fact table's full detail: columns (as JSON per entry), SQL, user ID types, and metadata
- `create_metric_exploration` — charts one or more fact metrics (`fact__` IDs) on a single exploration; supports multi-series, custom date ranges, chart types, and dimension breakdowns
- `create_fact_table_exploration` — runs an ad-hoc product-analytics query against a raw fact table; supports multiple series (row counts, distinct unit counts, or column sums), row filters, and dimensions

- Closes **(add link to issue here)**

### Dependencies
Depends on https://github.com/growthbook/growthbook-mcp/pull/45

None

### Testing

- [x] Can successfully answer the question of “How many fact tables do I have?”
- [x] Can answer the question of “what columns are available on fact table abc123?
- [x] Can answer the question of “are there any slice columns available on fact table abc123?
- [x] Can handle simple tasks like asking to see count of orders over the last 30 days (where `orders` is a fact-table)
- [x] Can then ask it to return the orders over time ( and ensure it returns a new exploration with a line chart instead of big number)
- [x] Then ask it to chart the sum of the amount for those orders
- [x] And then ask it to chart both the sum of the amount and the count of orders and ensure it returns a single chart with multiple values
- [x] Can handle building charts for a generic `events` table - where it will build a filter to chart specific events
- [x] Ensure it can handle building charts with multiple values or a single value with dimensions
