### PR TITLE
Add Data Source Exploration Tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - `list_fact_tables` tool — list fact tables with pagination and optional project or data source filters; use ids for product analytics and fact metrics workflows
 - `create_metric_exploration` tool — chart metric data over time with configurable date ranges and chart types, returns visualization data and a link to view in GrowthBook
 - `create_fact_table_exploration` tool — run product-analytics queries directly against a fact table (row count, unit count, sum of a column) with the same chart and date-range options as metric exploration
+- `list_datasources` tool — list all GrowthBook data sources with ids, names, and types; starting point for the data source exploration workflow
+- `get_datasource_schema` tool — explore a data source's available tables; when a `tableId` is provided, also returns column names and data types for that table
+- `create_data_source_exploration` tool — run a product-analytics query directly against a raw data source table; automatically fetches the table's column types and timestamp column before building the query payload; intended as a last resort when fact metrics and fact tables are unavailable
 
 ### Changed
 

--- a/manifest.json
+++ b/manifest.json
@@ -126,7 +126,7 @@
     },
     {
       "name": "create_data_source_exploration",
-      "description": "Run a GrowthBook product-analytics query directly against a raw data source table. Use only when create_metric_exploration and create_fact_table_exploration cannot satisfy the request. Requires datasourceId and tableId — use list_datasources then get_datasource_schema to discover these. Automatically fetches column types and timestamp column before running the query."
+      "description": "Run a GrowthBook product-analytics query directly against a raw data source table. Use only when create_metric_exploration and create_fact_table_exploration cannot satisfy the request. Requires datasourceId and tableId — use list_datasources then get_datasource_schema to discover these. Supports count and sum series. Automatically fetches column types and timestamp column before running the query."
     }
   ],
   "prompts": [

--- a/manifest.json
+++ b/manifest.json
@@ -115,6 +115,18 @@
     {
       "name": "create_fact_table_exploration",
       "description": "Chart data from a GrowthBook fact table. Requires factTableId and a series array (one or more entries: count, unit_count, or sum of a numeric column) so multiple series can appear on one chart. Use list_fact_tables and get_fact_table first. Returns exploration data and a GrowthBook chart link; same cache and date-range behavior as create_metric_exploration."
+    },
+    {
+      "name": "list_datasources",
+      "description": "List all GrowthBook data sources in the organization (id, name, type). Use a datasource id with get_datasource_schema to explore available tables and columns, or pass it to create_data_source_exploration to run an ad-hoc query."
+    },
+    {
+      "name": "get_datasource_schema",
+      "description": "Explore the schema of a GrowthBook data source. With only datasourceId, returns available tables. With datasourceId and tableId, also returns column names and data types for that table. Use list_datasources to find datasource ids. Use the returned tableId and column info with create_data_source_exploration."
+    },
+    {
+      "name": "create_data_source_exploration",
+      "description": "Run a GrowthBook product-analytics query directly against a raw data source table. Use only when create_metric_exploration and create_fact_table_exploration cannot satisfy the request. Requires datasourceId and tableId — use list_datasources then get_datasource_schema to discover these. Automatically fetches column types and timestamp column before running the query."
     }
   ],
   "prompts": [

--- a/src/api-type-helpers.ts
+++ b/src/api-type-helpers.ts
@@ -106,22 +106,40 @@ export type CreateDataSourceExplorationResponse =
   Paths["/product-analytics/data-source-exploration"]["post"]["responses"][200]["content"]["application/json"];
 
 // Information schema endpoints (new — pending OpenAPI spec regeneration)
+export type DatasourceInformationSchemaTable = {
+  id: string;
+  path: string;
+  tableName: string;
+  numOfColumns?: number;
+};
+
 export type DatasourceInformationSchemaResponse = {
-  tables: Array<{
+  informationSchema: {
     id: string;
-    path: string;
-    name?: string;
-    numColumns?: number;
-  }>;
+    datasourceId: string;
+    status: string;
+    databases: Array<{
+      databaseName: string;
+      path: string;
+      schemas: Array<{
+        schemaName: string;
+        path: string;
+        tables: Array<DatasourceInformationSchemaTable>;
+      }>;
+    }>;
+  };
 };
 
 export type TableInformationSchemaResponse = {
-  table: {
+  informationSchemaTable: {
     id: string;
-    path: string;
+    datasourceId: string;
+    tableName: string;
+    tableSchema: string;
+    databaseName: string;
     columns: Array<{
       columnName: string;
-      dataType: "string" | "number" | "date" | "boolean" | "other";
+      dataType: string;
     }>;
   };
 };

--- a/src/api-type-helpers.ts
+++ b/src/api-type-helpers.ts
@@ -104,3 +104,24 @@ export type CreateFactTableExplorationResponse =
   Paths["/product-analytics/fact-table-exploration"]["post"]["responses"][200]["content"]["application/json"];
 export type CreateDataSourceExplorationResponse =
   Paths["/product-analytics/data-source-exploration"]["post"]["responses"][200]["content"]["application/json"];
+
+// Information schema endpoints (new — pending OpenAPI spec regeneration)
+export type DatasourceInformationSchemaResponse = {
+  tables: Array<{
+    id: string;
+    path: string;
+    name?: string;
+    numColumns?: number;
+  }>;
+};
+
+export type TableInformationSchemaResponse = {
+  table: {
+    id: string;
+    path: string;
+    columns: Array<{
+      columnName: string;
+      dataType: "string" | "number" | "date" | "boolean" | "other";
+    }>;
+  };
+};

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -66,7 +66,14 @@ export function formatProjects(data: ListProjectsResponse): string {
 export function formatFactTablesList(data: ListFactTablesResponse): string {
   const tables = data.factTables || [];
   if (tables.length === 0) {
-    return "No fact tables found for the current filters.";
+    return (
+      "No fact tables found for the current filters.\n\n" +
+      "To answer product analytics questions without fact tables, use `create_data_source_exploration` directly:\n" +
+      "1. Call `list_datasources` to find available data source IDs.\n" +
+      "2. Call `get_datasource_schema` with the datasource ID to list tables.\n" +
+      "3. Call `get_datasource_schema` again with a tableId to inspect columns.\n" +
+      "4. Call `create_data_source_exploration` with the datasourceId, tableId, and a series definition."
+    );
   }
 
   const lines = tables.map((t) => {

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -20,6 +20,7 @@ import type {
   GetFactTableResponse,
   Feature,
   GetStaleFeatureResponse,
+  ListDataSourcesResponse,
 } from "./api-type-helpers.js";
 
 // Helper to resolve a metric ID to a display name using an optional lookup
@@ -768,6 +769,82 @@ export function formatStaleFeatureFlags(
   } else {
     parts.push("No stale flags found. All checked features are active.");
   }
+
+  return parts.join("\n");
+}
+
+// ─── Data Sources ───────────────────────────────────────────────────
+
+export function formatDatasourcesList(data: ListDataSourcesResponse): string {
+  const sources = data.dataSources || [];
+  if (sources.length === 0) {
+    return "No data sources found in this GrowthBook organization.";
+  }
+
+  const lines = sources.map((ds) => {
+    const parts = [`- **${ds.name}** (id: \`${ds.id}\`, type: \`${ds.type}\`)`];
+    if (ds.description?.trim()) parts.push(`  ${ds.description.trim()}`);
+    if (ds.projectIds?.length)
+      parts.push(`  Projects: ${ds.projectIds.map((p: string) => `\`${p}\``).join(", ")}`);
+    return parts.join("\n");
+  });
+
+  return [
+    `**${sources.length} data source(s):**`,
+    "",
+    ...lines,
+    "",
+    "Use a data source `id` with `get_datasource_schema` to explore available tables and columns.",
+  ].join("\n");
+}
+
+export function formatDatasourceTableList(
+  datasourceId: string,
+  tables: Array<{ id: string; path: string; name?: string; numColumns?: number }>
+): string {
+  if (tables.length === 0) {
+    return `No tables found for data source \`${datasourceId}\`.`;
+  }
+
+  const lines = tables.map((t) => {
+    const label = t.name && t.name !== t.path ? `${t.name} — \`${t.path}\`` : `\`${t.path}\``;
+    const colNote = t.numColumns != null ? ` (${t.numColumns} columns)` : "";
+    return `- **${label}**${colNote}\n  id: \`${t.id}\``;
+  });
+
+  return [
+    `**${tables.length} table(s) available on datasource \`${datasourceId}\`:**`,
+    "",
+    ...lines,
+    "",
+    "Call `get_datasource_schema` again with a `tableId` to see column names and types for a specific table. Then use that `tableId` with `create_data_source_exploration`.",
+  ].join("\n");
+}
+
+export function formatDatasourceTableDetail(
+  datasourceId: string,
+  tableId: string,
+  path: string,
+  timestampColumn: string | null,
+  columnTypes: Record<string, string>
+): string {
+  const cols = Object.entries(columnTypes);
+  const colLines = cols.map(([name, type]) => {
+    const isTimestamp = name === timestampColumn ? " *(timestamp)*" : "";
+    return `- \`${name}\` — ${type}${isTimestamp}`;
+  });
+
+  const parts = [
+    `**Table: \`${path}\`**`,
+    `Datasource: \`${datasourceId}\` | Table ID: \`${tableId}\``,
+    timestampColumn ? `Timestamp column: \`${timestampColumn}\`` : "*(No timestamp column detected — you may need to specify one manually.)*",
+    "",
+    `**${cols.length} column(s):**`,
+    "",
+    ...colLines,
+    "",
+    `Use tableId \`${tableId}\` with \`create_data_source_exploration\` to run an ad-hoc query against this table.`,
+  ];
 
   return parts.join("\n");
 }

--- a/src/tools/exploration-schemas.ts
+++ b/src/tools/exploration-schemas.ts
@@ -264,12 +264,6 @@ export const dataSourceExplorationSeriesSchema = z.discriminatedUnion("valueType
   }),
   z.object({
     name: z.string().describe("Legend label for this series."),
-    valueType: z.literal("unit_count"),
-    unit: z.string().nullable().optional(),
-    rowFilters: z.array(explorationRowFilterSchema).default([]),
-  }),
-  z.object({
-    name: z.string().describe("Legend label for this series."),
     valueType: z.literal("sum"),
     valueColumn: z
       .string()

--- a/src/tools/exploration-schemas.ts
+++ b/src/tools/exploration-schemas.ts
@@ -249,6 +249,54 @@ export type FactTableExplorationSeries = z.infer<
   typeof factTableExplorationSeriesSchema
 >;
 
+/** One series for data-source exploration `dataset.values[]` */
+export const dataSourceExplorationSeriesSchema = z.discriminatedUnion("valueType", [
+  z.object({
+    name: z
+      .string()
+      .describe("Legend label for this series in the chart and API results."),
+    valueType: z.literal("count"),
+    unit: z.string().nullable().optional().describe("Optional unit label for display."),
+    rowFilters: z
+      .array(explorationRowFilterSchema)
+      .default([])
+      .describe("Filters applied to rows before aggregating."),
+  }),
+  z.object({
+    name: z.string().describe("Legend label for this series."),
+    valueType: z.literal("unit_count"),
+    unit: z.string().nullable().optional(),
+    rowFilters: z.array(explorationRowFilterSchema).default([]),
+  }),
+  z.object({
+    name: z.string().describe("Legend label for this series."),
+    valueType: z.literal("sum"),
+    valueColumn: z
+      .string()
+      .min(1)
+      .describe(
+        "Numeric column to sum. Use get_datasource_schema with a tableId to list valid column names and types."
+      ),
+    unit: z.string().nullable().optional(),
+    rowFilters: z.array(explorationRowFilterSchema).default([]),
+  }),
+]);
+
+export type DataSourceExplorationSeries = z.infer<
+  typeof dataSourceExplorationSeriesSchema
+>;
+
+export function mapDataSourceSeriesToPayload(series: DataSourceExplorationSeries) {
+  return {
+    name: series.name,
+    type: "data_source" as const,
+    valueType: series.valueType,
+    valueColumn: series.valueType === "sum" ? series.valueColumn : null,
+    unit: series.unit ?? null,
+    rowFilters: series.rowFilters,
+  };
+}
+
 /** One fact metric series for metric exploration `dataset.values[]` */
 export const metricExplorationEntrySchema = z.object({
   metricId: z

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -8,20 +8,63 @@ import {
 import type {
   CreateExplorationResponse,
   CreateFactTableExplorationResponse,
+  CreateDataSourceExplorationResponse,
   GetFactTableResponse,
+  ListDataSourcesResponse,
+  DatasourceInformationSchemaResponse,
+  TableInformationSchemaResponse,
 } from "../api-type-helpers.js";
-import { formatExplorationResult, formatApiError } from "../format-responses.js";
+import {
+  formatExplorationResult,
+  formatApiError,
+  formatDatasourcesList,
+  formatDatasourceTableList,
+  formatDatasourceTableDetail,
+} from "../format-responses.js";
 import {
   explorationSharedInputSchema,
   buildDateRangePayload,
   buildDimensions,
   factTableExplorationSeriesSchema,
   mapFactTableSeriesToPayload,
+  dataSourceExplorationSeriesSchema,
+  mapDataSourceSeriesToPayload,
   metricExplorationEntrySchema,
 } from "./exploration-schemas.js";
 
 interface ProductAnalyticsTools extends BaseToolsInterface {
   appOrigin: string;
+}
+
+async function fetchDatasourceInfoSchema(
+  baseApiUrl: string,
+  apiKey: string,
+  datasourceId: string
+): Promise<DatasourceInformationSchemaResponse> {
+  const res = await fetchWithRateLimit(
+    `${baseApiUrl}/api/v1/data-sources/${encodeURIComponent(
+      datasourceId
+    )}/information-schema`,
+    { headers: buildHeaders(apiKey) }
+  );
+  await handleResNotOk(res);
+  return (await res.json()) as DatasourceInformationSchemaResponse;
+}
+
+async function fetchTableInfoSchema(
+  baseApiUrl: string,
+  apiKey: string,
+  datasourceId: string,
+  tableId: string
+): Promise<TableInformationSchemaResponse> {
+  const res = await fetchWithRateLimit(
+    `${baseApiUrl}/api/v1/data-sources/${encodeURIComponent(
+      datasourceId
+    )}/tables/${encodeURIComponent(tableId)}/information-schema`,
+    { headers: buildHeaders(apiKey) }
+  );
+  await handleResNotOk(res);
+  return (await res.json()) as TableInformationSchemaResponse;
 }
 
 async function resolveFactMetricDatasource(
@@ -260,16 +303,12 @@ export function registerProductAnalyticsTools({
       } catch (error) {
         const ids = metricEntries.map((m) => m.metricId).join(", ");
         throw new Error(
-          formatApiError(
-            error,
-            `creating metric exploration for '${ids}'`,
-            [
-              "Only fact metrics are supported — IDs must start with 'fact__'.",
-              "Use get_metrics to find available fact metric IDs.",
-              "Multiple metrics in one chart must share the same datasource.",
-              "If no fact metric matches, use create_fact_table_exploration or create_data_source_exploration instead.",
-            ]
-          )
+          formatApiError(error, `creating metric exploration for '${ids}'`, [
+            "Only fact metrics are supported — IDs must start with 'fact__'.",
+            "Use get_metrics to find available fact metric IDs.",
+            "Multiple metrics in one chart must share the same datasource.",
+            "If no fact metric matches, use create_fact_table_exploration or create_data_source_exploration instead.",
+          ])
         );
       }
     }
@@ -343,9 +382,10 @@ export function registerProductAnalyticsTools({
 
         await handleResNotOk(res);
 
-        const data = (await res.json()) as CreateFactTableExplorationResponse & {
-          explorationUrl?: string;
-        };
+        const data =
+          (await res.json()) as CreateFactTableExplorationResponse & {
+            explorationUrl?: string;
+          };
 
         const title =
           series.length > 1
@@ -369,6 +409,294 @@ export function registerProductAnalyticsTools({
               "Verify factTableId with list_fact_tables and get_fact_table.",
               "For sum series, valueColumn must be a numeric column on that fact table.",
               "Ensure your API key can read fact tables and run product analytics queries.",
+            ]
+          )
+        );
+      }
+    }
+  );
+
+  server.registerTool(
+    "list_datasources",
+    {
+      title: "List Data Sources",
+      description:
+        "Lists all GrowthBook data sources available in the organization. " +
+        "Returns the id, name, and type for each datasource. " +
+        "Use a datasource `id` with `get_datasource_schema` to explore available tables and columns, " +
+        "or pass it directly to `create_data_source_exploration` if the table details are already known. " +
+        "Prefer `create_metric_exploration` or `create_fact_table_exploration` over the data source explorer when possible.",
+      inputSchema: z.object({}),
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    async () => {
+      try {
+        const res = await fetchWithRateLimit(
+          `${baseApiUrl}/api/v1/data-sources`,
+          { headers: buildHeaders(apiKey) }
+        );
+        await handleResNotOk(res);
+        const data = (await res.json()) as ListDataSourcesResponse;
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatDatasourcesList(data),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(error, "listing data sources", [
+            "Ensure your API key has permission to read data sources.",
+          ])
+        );
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_datasource_schema",
+    {
+      title: "Get Datasource Schema",
+      description:
+        "Explores the schema of a GrowthBook data source. " +
+        "When called with only `datasourceId`, returns the list of available tables (with ids and paths). " +
+        "When called with both `datasourceId` and `tableId`, also returns the full column list with data types for that specific table. " +
+        "Use `list_datasources` to find a datasource id. " +
+        "Use the returned `tableId` and column names with `create_data_source_exploration` to run an ad-hoc query.",
+      inputSchema: z.object({
+        datasourceId: z
+          .string()
+          .describe(
+            "The data source ID (e.g. ds_...). Use list_datasources to find available IDs."
+          ),
+        tableId: z
+          .string()
+          .optional()
+          .describe(
+            "Optional. When provided, returns column names and types for this specific table. " +
+              "Omit to get only the list of available tables."
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    async ({ datasourceId, tableId }) => {
+      try {
+        const schemaData = await fetchDatasourceInfoSchema(
+          baseApiUrl,
+          apiKey,
+          datasourceId
+        );
+        const tables = schemaData.tables || [];
+
+        if (!tableId) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: formatDatasourceTableList(datasourceId, tables),
+              },
+            ],
+          };
+        }
+
+        const tableSchemaData = await fetchTableInfoSchema(
+          baseApiUrl,
+          apiKey,
+          datasourceId,
+          tableId
+        );
+
+        const tableInfo = tableSchemaData.table;
+        const columns = tableInfo?.columns || [];
+
+        const columnTypes: Record<string, string> = {};
+        for (const col of columns) {
+          columnTypes[col.columnName] = col.dataType;
+        }
+
+        const timestampColumn =
+          columns.find((c) => c.columnName === "timestamp")?.columnName ??
+          columns.find((c) => c.dataType === "date")?.columnName ??
+          null;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatDatasourceTableDetail(
+                datasourceId,
+                tableId,
+                tableInfo?.path ?? tableId,
+                timestampColumn,
+                columnTypes
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(
+            error,
+            `fetching schema for datasource '${datasourceId}'`,
+            [
+              "Verify the datasourceId with list_datasources.",
+              "If providing a tableId, verify it exists in the datasource information schema.",
+              "Ensure your API key has permission to read data source schemas.",
+            ]
+          )
+        );
+      }
+    }
+  );
+
+  const dataSourceExplorationInputSchema = explorationSharedInputSchema.extend({
+    datasourceId: z
+      .string()
+      .describe(
+        "The data source ID (e.g. ds_...). Use list_datasources to find IDs."
+      ),
+    tableId: z
+      .string()
+      .describe(
+        "The table ID to query. Use get_datasource_schema with a datasourceId to discover available table IDs."
+      ),
+    series: z
+      .array(dataSourceExplorationSeriesSchema)
+      .min(1)
+      .describe(
+        "One or more series to plot. Each series can be a row count, distinct unit count, or sum of a numeric column. " +
+          "Use get_datasource_schema with a tableId to discover valid column names and types. " +
+          "For valueType 'sum', valueColumn must be a numeric column."
+      ),
+  });
+
+  server.registerTool(
+    "create_data_source_exploration",
+    {
+      title: "Create Data Source Exploration",
+      description:
+        "Runs a GrowthBook product-analytics query directly against a raw data source table. " +
+        "Use this only when neither `create_metric_exploration` nor `create_fact_table_exploration` can satisfy the request. " +
+        "Requires a datasourceId and tableId — use `list_datasources` then `get_datasource_schema` to discover these. " +
+        "If there are tables with the same name in different datasources, ask the user to specify which data source they want to use." +
+        "If there are multiple timestamp columns on a particular table, ask the user to specify which timestamp column they want to use." +
+        "Automatically fetches the table's column types and timestamp column from the information schema before running the query. " +
+        "Returns chart data and a link to view the visualization in GrowthBook. " +
+        "If the response indicates the query is still running, wait 10–15 seconds and retry with cache 'preferred'.",
+      inputSchema: dataSourceExplorationInputSchema,
+      annotations: {
+        readOnlyHint: false,
+      },
+    },
+    async (input) => {
+      const {
+        datasourceId,
+        tableId,
+        series,
+        dateRange,
+        lookbackValue,
+        lookbackUnit,
+        startDate,
+        endDate,
+        cache,
+        chartType,
+        dateGranularity,
+        dimensions,
+      } = input;
+
+      try {
+        const tableSchemaData = await fetchTableInfoSchema(
+          baseApiUrl,
+          apiKey,
+          datasourceId,
+          tableId
+        );
+
+        const tableInfo = tableSchemaData.table;
+        const columns = tableInfo?.columns || [];
+
+        const columnTypes: Record<
+          string,
+          "string" | "number" | "date" | "boolean" | "other"
+        > = {};
+        for (const col of columns) {
+          columnTypes[col.columnName] = col.dataType;
+        }
+
+        const timestampColumn =
+          columns.find((c) => c.columnName === "timestamp")?.columnName ??
+          columns.find((c) => c.dataType === "date")?.columnName ??
+          "timestamp";
+
+        const path = tableInfo?.path ?? tableId;
+
+        const payload = {
+          datasource: datasourceId,
+          type: "data_source" as const,
+          chartType,
+          dateRange: buildDateRangePayload(
+            dateRange,
+            lookbackValue,
+            lookbackUnit,
+            startDate,
+            endDate
+          ),
+          dimensions: buildDimensions(dimensions, chartType, dateGranularity),
+          dataset: {
+            type: "data_source" as const,
+            path,
+            table: tableId,
+            timestampColumn,
+            columnTypes,
+            values: series.map(mapDataSourceSeriesToPayload),
+          },
+        };
+
+        const res = await fetchWithRateLimit(
+          `${baseApiUrl}/api/v1/product-analytics/data-source-exploration?cache=${cache}`,
+          {
+            method: "POST",
+            headers: buildHeaders(apiKey),
+            body: JSON.stringify(payload),
+          }
+        );
+
+        await handleResNotOk(res);
+
+        const data =
+          (await res.json()) as CreateDataSourceExplorationResponse & {
+            explorationUrl?: string;
+          };
+
+        const title =
+          series.length > 1
+            ? `${path} (${series.length} series)`
+            : `${path} — ${series[0].name}`;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatExplorationResult(data, title),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(
+            error,
+            `creating data source exploration for table '${tableId}'`,
+            [
+              "Use list_datasources to verify the datasourceId.",
+              "Use get_datasource_schema to verify the tableId and column names.",
+              "For sum series, valueColumn must be a numeric column — check get_datasource_schema output.",
+              "If no fact metric or fact table exists for this data, consider creating one in GrowthBook first.",
             ]
           )
         );

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -58,9 +58,9 @@ async function fetchTableInfoSchema(
   tableId: string
 ): Promise<TableInformationSchemaResponse> {
   const res = await fetchWithRateLimit(
-    `${baseApiUrl}/api/v1/data-sources/${encodeURIComponent(
-      datasourceId
-    )}/tables/${encodeURIComponent(tableId)}/information-schema`,
+    `${baseApiUrl}/api/v1/information-schema-tables/${encodeURIComponent(
+      tableId
+    )}`,
     { headers: buildHeaders(apiKey) }
   );
   await handleResNotOk(res);
@@ -433,17 +433,30 @@ export function registerProductAnalyticsTools({
     },
     async () => {
       try {
-        const res = await fetchWithRateLimit(
-          `${baseApiUrl}/api/v1/data-sources`,
-          { headers: buildHeaders(apiKey) }
-        );
-        await handleResNotOk(res);
-        const data = (await res.json()) as ListDataSourcesResponse;
+        const allSources: ListDataSourcesResponse["dataSources"] = [];
+        let offset = 0;
+        const limit = 100;
+        let hasMore = true;
+
+        while (hasMore) {
+          const res = await fetchWithRateLimit(
+            `${baseApiUrl}/api/v1/data-sources?limit=${limit}&offset=${offset}`,
+            { headers: buildHeaders(apiKey) }
+          );
+          await handleResNotOk(res);
+          const data = (await res.json()) as ListDataSourcesResponse;
+          allSources.push(...(data.dataSources || []));
+          hasMore = data.hasMore ?? false;
+          offset = data.nextOffset ?? offset + limit;
+        }
+
         return {
           content: [
             {
               type: "text" as const,
-              text: formatDatasourcesList(data),
+              text: formatDatasourcesList({
+                dataSources: allSources,
+              } as ListDataSourcesResponse),
             },
           ],
         };
@@ -564,7 +577,25 @@ export function registerProductAnalyticsTools({
     tableId: z
       .string()
       .describe(
-        "The table ID to query. Use get_datasource_schema with a datasourceId to discover available table IDs."
+        "The table ID (e.g. tbl_...) to query — NOT the table path. " +
+          "Use get_datasource_schema with a datasourceId to list tables and get their IDs. " +
+          "The table ID and table path are distinct: the ID is the GrowthBook identifier, the path is the fully-qualified table name in the database."
+      ),
+    tablePath: z
+      .string()
+      .optional()
+      .describe(
+        "The fully-qualified table path in the database (e.g. 'project.dataset.table' or 'schema.table'). " +
+          "Resolved automatically from the information schema when omitted. " +
+          "Provide this explicitly when you already know the path (e.g. from get_fact_table SQL or get_datasource_schema output) to skip the schema lookup."
+      ),
+    timestampColumn: z
+      .string()
+      .optional()
+      .describe(
+        "The timestamp column name for this table. " +
+          "Resolved automatically from the information schema when omitted; defaults to 'timestamp' if auto-detection fails. " +
+          "Provide this explicitly when you already know the column name (e.g. from get_fact_table or get_datasource_schema output)."
       ),
     series: z
       .array(dataSourceExplorationSeriesSchema)
@@ -584,9 +615,12 @@ export function registerProductAnalyticsTools({
         "Runs a GrowthBook product-analytics query directly against a raw data source table. " +
         "Use this only when neither `create_metric_exploration` nor `create_fact_table_exploration` can satisfy the request. " +
         "Requires a datasourceId and tableId — use `list_datasources` then `get_datasource_schema` to discover these. " +
-        "If there are tables with the same name in different datasources, ask the user to specify which data source they want to use." +
-        "If there are multiple timestamp columns on a particular table, ask the user to specify which timestamp column they want to use." +
-        "Automatically fetches the table's column types and timestamp column from the information schema before running the query. " +
+        "Note: tableId is the GrowthBook table identifier (e.g. tbl_...); tablePath is the fully-qualified database table name (e.g. project.dataset.table). These are distinct — always use the ID from get_datasource_schema, not the path. " +
+        "You may optionally supply tablePath and timestampColumn directly (e.g. from get_datasource_schema or get_fact_table output) to skip the automatic schema lookup. " +
+        "Don't assume you know what data source the user wants to use. Ask the user to specify the data source they want to use, but give them options to choose from. " +
+        "If there are tables with the same name in different datasources, ask the user to specify which data source they want to use. " +
+        "If there are multiple timestamp columns on a particular table, ask the user to specify which timestamp column they want to use. " +
+        "Attempts to auto-fetch column types, table path, and timestamp column from the information schema; falls back gracefully if unavailable. " +
         "Returns chart data and a link to view the visualization in GrowthBook. " +
         "If the response indicates the query is still running, wait 10–15 seconds and retry with cache 'preferred'.",
       inputSchema: dataSourceExplorationInputSchema,
@@ -598,6 +632,8 @@ export function registerProductAnalyticsTools({
       const {
         datasourceId,
         tableId,
+        tablePath: inputTablePath,
+        timestampColumn: inputTimestampColumn,
         series,
         dateRange,
         lookbackValue,
@@ -611,30 +647,37 @@ export function registerProductAnalyticsTools({
       } = input;
 
       try {
-        const tableSchemaData = await fetchTableInfoSchema(
-          baseApiUrl,
-          apiKey,
-          datasourceId,
-          tableId
-        );
-
-        const tableInfo = tableSchemaData.table;
-        const columns = tableInfo?.columns || [];
-
-        const columnTypes: Record<
+        let columnTypes: Record<
           string,
           "string" | "number" | "date" | "boolean" | "other"
         > = {};
-        for (const col of columns) {
-          columnTypes[col.columnName] = col.dataType;
+        let timestampColumn = inputTimestampColumn ?? "timestamp";
+        let path = inputTablePath ?? tableId;
+
+        try {
+          const tableSchemaData = await fetchTableInfoSchema(
+            baseApiUrl,
+            apiKey,
+            datasourceId,
+            tableId
+          );
+          const tableInfo = tableSchemaData.table;
+          const columns = tableInfo?.columns || [];
+          for (const col of columns) {
+            columnTypes[col.columnName] = col.dataType;
+          }
+          if (!inputTimestampColumn) {
+            timestampColumn =
+              columns.find((c) => c.columnName === "timestamp")?.columnName ??
+              columns.find((c) => c.dataType === "date")?.columnName ??
+              "timestamp";
+          }
+          if (!inputTablePath) {
+            path = tableInfo?.path ?? tableId;
+          }
+        } catch {
+          // Information schema unavailable — proceed with provided/default values
         }
-
-        const timestampColumn =
-          columns.find((c) => c.columnName === "timestamp")?.columnName ??
-          columns.find((c) => c.dataType === "date")?.columnName ??
-          "timestamp";
-
-        const path = tableInfo?.path ?? tableId;
 
         const payload = {
           datasource: datasourceId,

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -12,6 +12,7 @@ import type {
   GetFactTableResponse,
   ListDataSourcesResponse,
   DatasourceInformationSchemaResponse,
+  DatasourceInformationSchemaTable,
   TableInformationSchemaResponse,
 } from "../api-type-helpers.js";
 import {
@@ -36,11 +37,22 @@ interface ProductAnalyticsTools extends BaseToolsInterface {
   appOrigin: string;
 }
 
+type NormalizedDataType = "string" | "number" | "date" | "boolean" | "other";
+
+function mapSqlDataType(raw: string): NormalizedDataType {
+  const t = raw.toLowerCase();
+  if (t.includes("char") || t.includes("text") || t.includes("uuid") || t.includes("enum")) return "string";
+  if (t.includes("int") || t.includes("numeric") || t.includes("decimal") || t.includes("float") || t.includes("double") || t.includes("real") || t.includes("money")) return "number";
+  if (t.includes("timestamp") || t.includes("date") || t.includes("time")) return "date";
+  if (t.includes("bool")) return "boolean";
+  return "other";
+}
+
 async function fetchDatasourceInfoSchema(
   baseApiUrl: string,
   apiKey: string,
   datasourceId: string
-): Promise<DatasourceInformationSchemaResponse> {
+): Promise<DatasourceInformationSchemaTable[]> {
   const res = await fetchWithRateLimit(
     `${baseApiUrl}/api/v1/data-sources/${encodeURIComponent(
       datasourceId
@@ -48,7 +60,16 @@ async function fetchDatasourceInfoSchema(
     { headers: buildHeaders(apiKey) }
   );
   await handleResNotOk(res);
-  return (await res.json()) as DatasourceInformationSchemaResponse;
+  const data = (await res.json()) as DatasourceInformationSchemaResponse;
+  const tables: DatasourceInformationSchemaTable[] = [];
+  for (const db of data.informationSchema?.databases ?? []) {
+    for (const schema of db.schemas ?? []) {
+      for (const table of schema.tables ?? []) {
+        tables.push(table);
+      }
+    }
+  }
+  return tables;
 }
 
 async function fetchTableInfoSchema(
@@ -500,12 +521,17 @@ export function registerProductAnalyticsTools({
     },
     async ({ datasourceId, tableId }) => {
       try {
-        const schemaData = await fetchDatasourceInfoSchema(
+        const rawTables = await fetchDatasourceInfoSchema(
           baseApiUrl,
           apiKey,
           datasourceId
         );
-        const tables = schemaData.tables || [];
+        const tables = rawTables.map((t) => ({
+          id: t.id,
+          path: t.path,
+          name: t.tableName,
+          numColumns: t.numOfColumns,
+        }));
 
         if (!tableId) {
           return {
@@ -525,18 +551,22 @@ export function registerProductAnalyticsTools({
           tableId
         );
 
-        const tableInfo = tableSchemaData.table;
+        const tableInfo = tableSchemaData.informationSchemaTable;
         const columns = tableInfo?.columns || [];
 
         const columnTypes: Record<string, string> = {};
         for (const col of columns) {
-          columnTypes[col.columnName] = col.dataType;
+          columnTypes[col.columnName] = mapSqlDataType(col.dataType);
         }
 
         const timestampColumn =
           columns.find((c) => c.columnName === "timestamp")?.columnName ??
-          columns.find((c) => c.dataType === "date")?.columnName ??
+          columns.find((c) => mapSqlDataType(c.dataType) === "date")?.columnName ??
           null;
+
+        const tablePath = tableInfo
+          ? `${tableInfo.databaseName}.${tableInfo.tableSchema}.${tableInfo.tableName}`
+          : tableId;
 
         return {
           content: [
@@ -545,7 +575,7 @@ export function registerProductAnalyticsTools({
               text: formatDatasourceTableDetail(
                 datasourceId,
                 tableId,
-                tableInfo?.path ?? tableId,
+                tablePath,
                 timestampColumn,
                 columnTypes
               ),
@@ -661,19 +691,21 @@ export function registerProductAnalyticsTools({
             datasourceId,
             tableId
           );
-          const tableInfo = tableSchemaData.table;
+          const tableInfo = tableSchemaData.informationSchemaTable;
           const columns = tableInfo?.columns || [];
           for (const col of columns) {
-            columnTypes[col.columnName] = col.dataType;
+            columnTypes[col.columnName] = mapSqlDataType(col.dataType);
           }
           if (!inputTimestampColumn) {
             timestampColumn =
               columns.find((c) => c.columnName === "timestamp")?.columnName ??
-              columns.find((c) => c.dataType === "date")?.columnName ??
+              columns.find((c) => mapSqlDataType(c.dataType) === "date")?.columnName ??
               "timestamp";
           }
           if (!inputTablePath) {
-            path = tableInfo?.path ?? tableId;
+            path = tableInfo
+              ? `${tableInfo.databaseName}.${tableInfo.tableSchema}.${tableInfo.tableName}`
+              : tableId;
           }
         } catch {
           // Information schema unavailable — proceed with provided/default values

--- a/src/tools/product-analytics.ts
+++ b/src/tools/product-analytics.ts
@@ -631,7 +631,7 @@ export function registerProductAnalyticsTools({
       .array(dataSourceExplorationSeriesSchema)
       .min(1)
       .describe(
-        "One or more series to plot. Each series can be a row count, distinct unit count, or sum of a numeric column. " +
+        "One or more series to plot. Each series can be a row count ('count') or sum of a numeric column ('sum'). " +
           "Use get_datasource_schema with a tableId to discover valid column names and types. " +
           "For valueType 'sum', valueColumn must be a numeric column."
       ),
@@ -643,7 +643,7 @@ export function registerProductAnalyticsTools({
       title: "Create Data Source Exploration",
       description:
         "Runs a GrowthBook product-analytics query directly against a raw data source table. " +
-        "Use this only when neither `create_metric_exploration` nor `create_fact_table_exploration` can satisfy the request. " +
+        "Use this when neither `create_metric_exploration` nor `create_fact_table_exploration` can satisfy the request — including when no fact tables exist (i.e. `list_fact_tables` returns empty). " +
         "Requires a datasourceId and tableId — use `list_datasources` then `get_datasource_schema` to discover these. " +
         "Note: tableId is the GrowthBook table identifier (e.g. tbl_...); tablePath is the fully-qualified database table name (e.g. project.dataset.table). These are distinct — always use the ID from get_datasource_schema, not the path. " +
         "You may optionally supply tablePath and timestampColumn directly (e.g. from get_datasource_schema or get_fact_table output) to skip the automatic schema lookup. " +


### PR DESCRIPTION
### Features and Changes

Adds product analytics tooling to the GrowthBook MCP server, enabling AI agents to query and chart data directly from GrowthBook data sources.

**New tools:**
- `list_datasources` — list all data sources in the organization
- `get_datasource_schema` — explore a datasource's available tables; when a `tableId` is provided, also returns column names and normalized data types
- `create_data_source_exploration` — run product analytics queries directly against a raw datasource table; auto-resolves column types, table path, and timestamp column from the information schema before building the query payload

- Closes **(add link to issue here)**

### Dependencies
- Depends on https://github.com/growthbook/growthbook-mcp/pull/46

None

### Testing
This one is a bit harder to test - the MCP server is instructed to use the `create_data_source_exploration` tool as a last resort, if the `create_metric_exploration` and `create_fact_table_exploration` aren't able to solve the users query. To get around this for testing, I created a new account that didn't have any fact tables or metrics so the MCP was forced to use the `create_data_source_exploration` tool.

- [x] Validate that an org is able to ask a question about a data source, and it returns a valid data source type exploration. In this case, I asked it to chart my orders over time - and it found the `orders` table in my data source and built it based on that.
- [x] Give it a task that it isn't capable of, and ensure it spits out a correct response indicating so
- [x] Ask it to chart data from a data source that has a generic `events` table. In this case, I asked it to chart how many customers added an item to the cart - it correctly found the events table, identified the column to filter on, and created a valid value for the filter.
- [x] Ensure that the MCP server only uses this tool as a last resort - after trying the create metrics tool and the create fact table tool.