### PR TITLE
feat: add http transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# AGENTS.md
+
+This file provides guidance when working with the GrowthBook MCP server codebase.
+
+## Build & Test Commands
+
+```bash
+npm run build          # TypeScript compilation (tsc)
+npm run dev            # Watch mode
+npm test               # Run all tests (vitest)
+npx vitest run         # Alternative test runner
+npm run generate-api-types  # Regenerate API types from OpenAPI spec
+```
+
+## Version Management
+
+Version lives in `package.json` and must be synced to `manifest.json` and `server.json`.
+
+```bash
+npm run bump:minor     # Bump minor version + sync all files
+npm run bump:patch     # Bump patch version + sync all files
+npm run sync-version   # Sync version from package.json → manifest.json + server.json
+```
+
+**Do NOT manually edit versions in manifest.json or server.json** — use the bump scripts or edit `package.json` then run `npm run sync-version`.
+
+## Architecture
+
+### Source Structure
+
+```
+src/
+  index.ts              # Server entry point, registers all tool groups
+  utils.ts              # Shared utilities (fetch, schemas, headers, rate limiting)
+  format-responses.ts   # Response formatters for all tools (agent-friendly output)
+  api-types.d.ts        # Auto-generated from OpenAPI spec (do not edit manually)
+  api-type-helpers.ts   # Typed aliases for specific API responses
+  docs.ts               # SDK code snippets per language
+  tools/
+    features.ts         # Feature flag tools (create, get, list keys, stale check)
+    experiments/
+      experiments.ts    # Experiment tools (get, create, attributes)
+      experiment-summary.ts  # Summary mode logic and metric resolution
+    defaults.ts         # Experiment defaults management
+    environments.ts     # Environment listing
+    projects.ts         # Project listing
+    sdk-connections.ts  # SDK connection tools
+    metrics.ts          # Metrics tools
+    search.ts           # Documentation search
+  prompts/              # MCP prompt registrations
+  types/                # TypeScript type definitions
+```
+
+### Key Patterns
+
+**Tool registration**: Each tool group has a `register*Tools()` function that receives `{ server, baseApiUrl, apiKey, ... }` and registers tools via `server.registerTool()`.
+
+**Response formatting**: All tool responses go through formatters in `format-responses.ts`. Never return raw `JSON.stringify()` — use or create a formatter that produces agent-friendly markdown output. List views should be scannable summaries; detail views should include full configuration.
+
+**API calls**: Use `fetchWithRateLimit()` for all API calls (adds courtesy delays and retry on 429). Use `buildHeaders(apiKey)` for request headers. Use `handleResNotOk(res)` to throw on non-2xx responses.
+
+**Error handling**: Use `formatApiError(error, context, suggestions)` to produce errors with actionable suggestions for the agent.
+
+**Input schemas**: Use Zod for all tool input schemas. Reuse schemas from `featureFlagSchema` in utils.ts where applicable. File extension uses `SUPPORTED_FILE_EXTENSIONS` constant.
+
+## Adding a New Tool
+
+1. **Add the tool** in the appropriate file under `src/tools/`. Use `server.registerTool()` with a Zod input schema.
+2. **Add a formatter** in `src/format-responses.ts` if the tool returns data. Follow the existing pattern of returning markdown-formatted strings.
+3. **Add to manifest.json** — add a `{ "name": "tool_name", "description": "..." }` entry in the `tools` array. This is used by MCP registries.
+4. **Update the docs** — add the tool to `docs/docs/integrations/mcp.mdx` in the growthbook repo (under the appropriate Tools subsection).
+5. **Update CHANGELOG.md** — add the tool under the current version's `### Added` section.
+6. **Run build and tests** — `npm run build && npm test`.
+
+### Tool Description Best Practices
+
+Tool descriptions directly influence how well AI agents use the tool. Follow these guidelines:
+
+- **Lead with what the tool needs** — if a parameter is required, say so upfront (e.g., "Given a list of feature flag IDs, checks whether...")
+- **Reference other tools** — tell the agent which tools to use first (e.g., "Use list_feature_keys to get all flag IDs")
+- **Keep it language-agnostic** — don't reference JS-specific SDK methods; users may be in Python, Go, Ruby, etc.
+- **Avoid modes when possible** — simpler tools with a single response shape are easier for agents to use correctly
+- **Handle missing required params gracefully** — return a helpful response (not an error) guiding the agent on how to gather the data
+
+## Files That Must Stay in Sync
+
+When making changes, ensure these files are updated together:
+
+| Change | Files to update |
+|--------|----------------|
+| New tool | `src/tools/*.ts`, `manifest.json`, docs `mcp.mdx`, `CHANGELOG.md` |
+| Version bump | `package.json` → run `npm run sync-version` → updates `manifest.json` + `server.json` |
+| API schema changes | Run `npm run generate-api-types`, update `api-type-helpers.ts` if needed |
+| Tool rename/remove | `src/tools/*.ts`, `src/format-responses.ts` (formatters), `manifest.json`, docs `mcp.mdx`, `CHANGELOG.md` |
+
+## API Types
+
+`src/api-types.d.ts` is auto-generated from GrowthBook's OpenAPI spec. Do not edit it manually.
+
+```bash
+npm run generate-api-types
+```
+
+`src/api-type-helpers.ts` provides concrete type aliases for API responses used in tools:
+
+```typescript
+export type GetStaleFeatureResponse =
+  Paths["/stale-features"]["get"]["responses"][200]["content"]["application/json"];
+```
+
+Add new type aliases here when working with new API endpoints.
+
+## Testing
+
+Tests use Vitest and live in `test/`. The project tests utility functions and tool registration — not individual API responses (those depend on live data).
+
+Key test files:
+- `test/tools/readonly-tools.test.ts` — verifies read-only tools are registered with correct annotations
+- `test/tools/defaults.test.ts` — tests experiment defaults logic
+- `test/tools/experiments/summary-logic.test.ts` — tests experiment summary formatting
+
+## External Documentation
+
+The MCP docs page lives in the main GrowthBook repo at `docs/docs/integrations/mcp.mdx`. When adding or removing tools, update that file too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Local, single-tenant Streamable HTTP transport entrypoint with optional bearer-token protection for the MCP endpoint
 - `create_metric_exploration` tool — chart metric data over time with configurable date ranges and chart types, returns visualization data and a link to view in GrowthBook
 
 ## [1.8.1] - 2026-03-09

--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ Use the following env variables to configure the MCP server.
 | GB_HTTP_HEADER_* | Optional | Custom HTTP headers to include in all GrowthBook API requests. Use the pattern `GB_HTTP_HEADER_<NAME>` where `<NAME>` is converted to proper HTTP header format (underscores become hyphens). Examples: `GB_HTTP_HEADER_X_TENANT_ID=abc123` becomes `X-Tenant-ID: abc123`, `GB_HTTP_HEADER_CF_ACCESS_TOKEN=<token>` becomes `Cf-Access-Token: <token>`. Multiple custom headers can be configured. |
 
 Add the MCP server to your AI tool of choice. See the [official docs](https://docs.growthbook.io/integrations/mcp) for complete a complete guide.
+
+## Local HTTP Transport
+
+The default package entrypoint uses stdio. For local, single-tenant Streamable HTTP transport, build the server and run:
+
+```bash
+npm run build
+GB_API_KEY=... GB_EMAIL=you@example.com npm run start:http
+```
+
+By default, the HTTP server listens on `http://127.0.0.1:3000/mcp` and reuses the same `GB_API_KEY` and `GB_EMAIL` environment variables for all MCP clients.
+
+Optional HTTP environment variables:
+
+| Variable Name | Status | Description |
+| ------------- | ------ | ----------- |
+| MCP_HTTP_PORT | Optional | Local HTTP port. Defaults to `3000`. |
+| MCP_HTTP_HOST | Optional | Loopback host only (`127.0.0.1`, `localhost`, or `::1`). Defaults to `127.0.0.1`. |
+| MCP_HTTP_PATH | Optional | MCP endpoint path. Defaults to `/mcp`. |
+| MCP_SERVER_TOKEN | Optional | If set, clients must send `Authorization: Bearer <token>` when calling the local MCP endpoint. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
+        "growthbook-mcp-http": "server/http.js",
         "mcp": "server/index.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "start:http": "node server/http.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -23,7 +24,8 @@
     "generate-api-types": "npx openapi-typescript https://api.growthbook.io/api/v1/openapi.yaml -o src/api-types.d.ts"
   },
   "bin": {
-    "mcp": "server/index.js"
+    "mcp": "server/index.js",
+    "growthbook-mcp-http": "server/http.js"
   },
   "files": [
     "server"

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import {
+  createGrowthBookMcpServer,
+  getGrowthBookMcpConfig,
+} from "./server.js";
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 3000;
+const DEFAULT_PATH = "/mcp";
+
+type GrowthBookMcpServer = ReturnType<typeof createGrowthBookMcpServer>;
+
+interface SessionEntry {
+  server: GrowthBookMcpServer;
+  transport: StreamableHTTPServerTransport;
+  markClosing: () => void;
+}
+
+function getHttpHost() {
+  const host = process.env.MCP_HTTP_HOST?.trim() || DEFAULT_HOST;
+
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      `MCP_HTTP_HOST must be a loopback host for local HTTP transport. Received "${host}".`
+    );
+  }
+
+  return host;
+}
+
+function getHttpPort() {
+  const rawPort = process.env.MCP_HTTP_PORT?.trim();
+
+  if (!rawPort) {
+    return DEFAULT_PORT;
+  }
+
+  const port = Number(rawPort);
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `MCP_HTTP_PORT must be an integer between 1 and 65535. Received "${rawPort}".`
+    );
+  }
+
+  return port;
+}
+
+function getHttpPath() {
+  const path = process.env.MCP_HTTP_PATH?.trim() || DEFAULT_PATH;
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function getHeader(req: any, name: string): string | undefined {
+  const value = req.headers[name.toLowerCase()];
+
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function getSessionId(req: any) {
+  return getHeader(req, "mcp-session-id");
+}
+
+function sendJsonRpcError(res: any, status: number, code: number, message: string) {
+  res.status(status).json({
+    jsonrpc: "2.0",
+    error: {
+      code,
+      message,
+    },
+    id: null,
+  });
+}
+
+function verifyMcpServerToken(req: any, res: any) {
+  const token = process.env.MCP_SERVER_TOKEN?.trim();
+
+  if (!token) {
+    return true;
+  }
+
+  const authorization = getHeader(req, "authorization");
+
+  if (authorization === `Bearer ${token}`) {
+    return true;
+  }
+
+  sendJsonRpcError(res, 401, -32001, "Unauthorized");
+  return false;
+}
+
+async function closeSession(sessionId: string, entry: SessionEntry) {
+  sessions.delete(sessionId);
+  entry.markClosing();
+  await entry.server.close();
+}
+
+async function closeAllSessions() {
+  const entries = [...sessions.entries()];
+  await Promise.all(entries.map(([sessionId, entry]) => closeSession(sessionId, entry)));
+}
+
+const config = getGrowthBookMcpConfig();
+const host = getHttpHost();
+const port = getHttpPort();
+const path = getHttpPath();
+const sessions = new Map<string, SessionEntry>();
+const app = createMcpExpressApp({ host });
+
+app.get("/health", (_req: any, res: any) => {
+  res.json({
+    status: "ok",
+    transport: "streamable-http",
+    sessions: sessions.size,
+  });
+});
+
+app.post(path, async (req: any, res: any) => {
+  if (!verifyMcpServerToken(req, res)) {
+    return;
+  }
+
+  const sessionId = getSessionId(req);
+
+  try {
+    if (sessionId) {
+      const entry = sessions.get(sessionId);
+
+      if (!entry) {
+        sendJsonRpcError(res, 404, -32000, "Unknown MCP session ID.");
+        return;
+      }
+
+      await entry.transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    if (!isInitializeRequest(req.body)) {
+      sendJsonRpcError(
+        res,
+        400,
+        -32000,
+        "Missing MCP session ID. Start with an initialize request."
+      );
+      return;
+    }
+
+    const server = createGrowthBookMcpServer(config);
+    let transport!: StreamableHTTPServerTransport;
+    let closing = false;
+
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (newSessionId) => {
+        sessions.set(newSessionId, {
+          server,
+          transport,
+          markClosing: () => {
+            closing = true;
+          },
+        });
+      },
+    });
+
+    transport.onclose = () => {
+      const closedSessionId = transport.sessionId;
+
+      if (closedSessionId) {
+        sessions.delete(closedSessionId);
+      }
+
+      if (!closing) {
+        closing = true;
+        void server.close().catch((error) => {
+          console.error("Error closing MCP server:", error);
+        });
+      }
+    };
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error("Error handling MCP HTTP request:", error);
+
+    if (!res.headersSent) {
+      sendJsonRpcError(res, 500, -32603, "Internal server error");
+    }
+  }
+});
+
+app.get(path, async (req: any, res: any) => {
+  if (!verifyMcpServerToken(req, res)) {
+    return;
+  }
+
+  const sessionId = getSessionId(req);
+
+  if (!sessionId) {
+    sendJsonRpcError(res, 400, -32000, "Missing MCP session ID.");
+    return;
+  }
+
+  const entry = sessions.get(sessionId);
+
+  if (!entry) {
+    sendJsonRpcError(res, 404, -32000, "Unknown MCP session ID.");
+    return;
+  }
+
+  await entry.transport.handleRequest(req, res);
+});
+
+app.delete(path, async (req: any, res: any) => {
+  if (!verifyMcpServerToken(req, res)) {
+    return;
+  }
+
+  const sessionId = getSessionId(req);
+
+  if (!sessionId) {
+    sendJsonRpcError(res, 400, -32000, "Missing MCP session ID.");
+    return;
+  }
+
+  const entry = sessions.get(sessionId);
+
+  if (!entry) {
+    sendJsonRpcError(res, 404, -32000, "Unknown MCP session ID.");
+    return;
+  }
+
+  await entry.transport.handleRequest(req, res);
+});
+
+const httpServer = app.listen(port, host, () => {
+  const displayHost = host.includes(":") ? `[${host}]` : host;
+  const authMode = process.env.MCP_SERVER_TOKEN?.trim() ? "enabled" : "disabled";
+  console.error(
+    `GrowthBook MCP HTTP server listening at http://${displayHost}:${port}${path} (MCP auth: ${authMode})`
+  );
+});
+
+httpServer.on("error", (error: Error) => {
+  console.error("Failed to start MCP HTTP server:", error);
+  process.exit(1);
+});
+
+async function shutdown(signal: NodeJS.Signals) {
+  console.error(`Received ${signal}, shutting down MCP HTTP server...`);
+
+  try {
+    await closeAllSessions();
+  } catch (error) {
+    console.error("Error closing MCP HTTP sessions:", error);
+  }
+
+  httpServer.close((error?: Error) => {
+    if (error) {
+      console.error("Error closing MCP HTTP listener:", error);
+      process.exit(1);
+    }
+
+    process.exit(0);
+  });
+}
+
+process.on("SIGINT", (signal) => {
+  void shutdown(signal);
+});
+
+process.on("SIGTERM", (signal) => {
+  void shutdown(signal);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,116 +1,19 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { registerEnvironmentTools } from "./tools/environments.js";
-import { registerExperimentTools } from "./tools/experiments/experiments.js";
-import { registerFeatureTools } from "./tools/features.js";
-import { registerProjectTools } from "./tools/projects.js";
-import { registerSdkConnectionTools } from "./tools/sdk-connections.js";
-import { getApiKey, getApiUrl, getAppOrigin } from "./utils.js";
-import { registerSearchTools } from "./tools/search.js";
-import { registerDefaultsTools } from "./tools/defaults.js";
-import { registerMetricsTools } from "./tools/metrics.js";
-import { registerProductAnalyticsTools } from "./tools/product-analytics.js";
-import { registerExperimentPrompts } from "./prompts/experiment-prompts.js";
-import packageDetails from "../package.json" with { type: "json" };
+import {
+  createGrowthBookMcpServer,
+  getGrowthBookMcpConfig,
+} from "./server.js";
 
-export const baseApiUrl = getApiUrl();
-export const apiKey = getApiKey();
-export const appOrigin = getAppOrigin();
-export const user = process.env.GB_EMAIL;
+const config = getGrowthBookMcpConfig();
 
-if (!user) {
-  throw new Error("GB_EMAIL is not set in the environment variables");
-}
+export const baseApiUrl = config.baseApiUrl;
+export const apiKey = config.apiKey;
+export const appOrigin = config.appOrigin;
+export const user = config.user;
 
-// Create an MCP server
-const server = new McpServer(
-  {
-    name: "GrowthBook MCP",
-    version: packageDetails.version,
-    title: "GrowthBook MCP",
-    websiteUrl: "https://growthbook.io",
-  },
-  {
-    instructions: `You are a helpful assistant that interacts with GrowthBook, an open source feature flagging and experimentation platform.
-
-Key workflows:
-- Feature flags: Use create_feature_flag for simple flags, then create_force_rule to add targeting conditions
-- Experiments: ALWAYS call get_defaults first, then create_experiment. Experiments are created as "draft" - users must launch in GrowthBook UI
-- Analysis: Use get_experiments with mode="summary" for quick insights
-- Product analytics: Use create_metric_exploration to chart metric data. Use get_metrics first to find the metric ID.
-
-All mutating tools require a fileExtension parameter for SDK integration guidance.`,
-    capabilities: {
-      tools: {},
-      prompts: {},
-    },
-  }
-);
-
-registerEnvironmentTools({
-  server,
-  baseApiUrl,
-  apiKey,
-});
-
-registerProjectTools({
-  server,
-  baseApiUrl,
-  apiKey,
-});
-
-registerSdkConnectionTools({
-  server,
-  baseApiUrl,
-  apiKey,
-});
-
-registerFeatureTools({
-  server,
-  baseApiUrl,
-  apiKey,
-  appOrigin,
-  user,
-});
-
-registerExperimentTools({
-  server,
-  baseApiUrl,
-  apiKey,
-  appOrigin,
-  user,
-});
-
-registerSearchTools({
-  server,
-});
-
-registerDefaultsTools({
-  server,
-  baseApiUrl,
-  apiKey,
-});
-
-registerMetricsTools({
-  server,
-  baseApiUrl,
-  apiKey,
-  appOrigin,
-  user,
-});
-
-registerProductAnalyticsTools({
-  server,
-  baseApiUrl,
-  apiKey,
-  appOrigin,
-});
-
-registerExperimentPrompts({
-  server,
-});
+const server = createGrowthBookMcpServer(config);
 
 // Start receiving messages on stdin and sending messages on stdout
 const transport = new StdioServerTransport();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,131 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerEnvironmentTools } from "./tools/environments.js";
+import { registerExperimentTools } from "./tools/experiments/experiments.js";
+import { registerFeatureTools } from "./tools/features.js";
+import { registerProjectTools } from "./tools/projects.js";
+import { registerSdkConnectionTools } from "./tools/sdk-connections.js";
+import { getApiKey, getApiUrl, getAppOrigin } from "./utils.js";
+import { registerSearchTools } from "./tools/search.js";
+import { registerDefaultsTools } from "./tools/defaults.js";
+import { registerMetricsTools } from "./tools/metrics.js";
+import { registerProductAnalyticsTools } from "./tools/product-analytics.js";
+import { registerExperimentPrompts } from "./prompts/experiment-prompts.js";
+import packageDetails from "../package.json" with { type: "json" };
+
+export interface GrowthBookMcpConfig {
+  baseApiUrl: string;
+  apiKey: string;
+  appOrigin: string;
+  user: string;
+}
+
+export function getGrowthBookMcpConfig(): GrowthBookMcpConfig {
+  const user = process.env.GB_EMAIL;
+
+  if (!user) {
+    throw new Error("GB_EMAIL is not set in the environment variables");
+  }
+
+  return {
+    baseApiUrl: getApiUrl(),
+    apiKey: getApiKey(),
+    appOrigin: getAppOrigin(),
+    user,
+  };
+}
+
+export function createGrowthBookMcpServer({
+  baseApiUrl,
+  apiKey,
+  appOrigin,
+  user,
+}: GrowthBookMcpConfig) {
+  const server = new McpServer(
+    {
+      name: "GrowthBook MCP",
+      version: packageDetails.version,
+      title: "GrowthBook MCP",
+      websiteUrl: "https://growthbook.io",
+    },
+    {
+      instructions: `You are a helpful assistant that interacts with GrowthBook, an open source feature flagging and experimentation platform.
+
+Key workflows:
+- Feature flags: Use create_feature_flag for simple flags, then create_force_rule to add targeting conditions
+- Experiments: ALWAYS call get_defaults first, then create_experiment. Experiments are created as "draft" - users must launch in GrowthBook UI
+- Analysis: Use get_experiments with mode="summary" for quick insights
+- Product analytics: Use create_metric_exploration to chart metric data. Use get_metrics first to find the metric ID.
+
+All mutating tools require a fileExtension parameter for SDK integration guidance.`,
+      capabilities: {
+        tools: {},
+        prompts: {},
+      },
+    }
+  );
+
+  registerEnvironmentTools({
+    server,
+    baseApiUrl,
+    apiKey,
+  });
+
+  registerProjectTools({
+    server,
+    baseApiUrl,
+    apiKey,
+  });
+
+  registerSdkConnectionTools({
+    server,
+    baseApiUrl,
+    apiKey,
+  });
+
+  registerFeatureTools({
+    server,
+    baseApiUrl,
+    apiKey,
+    appOrigin,
+    user,
+  });
+
+  registerExperimentTools({
+    server,
+    baseApiUrl,
+    apiKey,
+    appOrigin,
+    user,
+  });
+
+  registerSearchTools({
+    server,
+  });
+
+  registerDefaultsTools({
+    server,
+    baseApiUrl,
+    apiKey,
+  });
+
+  registerMetricsTools({
+    server,
+    baseApiUrl,
+    apiKey,
+    appOrigin,
+    user,
+  });
+
+  registerProductAnalyticsTools({
+    server,
+    baseApiUrl,
+    apiKey,
+    appOrigin,
+  });
+
+  registerExperimentPrompts({
+    server,
+  });
+
+  return server;
+}


### PR DESCRIPTION
I would like to add HTTP transport, so I can run the MCP outside of my computer or inside container and make requests.

I have added the HTTP transport, which is not for production as there is no MCP public authentication layer.