### PR TITLE
feat: include ownerEmail in experiment responses

### DIFF
--- a/src/api-types.d.ts
+++ b/src/api-types.d.ts
@@ -2642,6 +2642,8 @@ export interface components {
             description: string;
             tags: string[];
             owner: string;
+            /** @description Resolved email address of the experiment owner */
+            ownerEmail?: string;
             archived: boolean;
             status: string;
             autoRefresh: boolean;

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -416,7 +416,9 @@ export function formatExperimentList(data: ListExperimentsResponse): string {
       e.id
     }\`, status: ${status})\n  Variations: ${variations}${
       goalCount > 0 ? ` | Goals: ${goalCount} metric(s)` : ""
-    }${e.project ? ` | Project: ${e.project}` : ""}`;
+    }${e.project ? ` | Project: ${e.project}` : ""}${
+      e.ownerEmail ? ` | Owner: ${e.ownerEmail}` : e.owner ? ` | Owner: ${e.owner}` : ""
+    }`;
   });
 
   const pagination = data.hasMore
@@ -466,7 +468,11 @@ export function formatExperimentDetail(
   if (e.trackingKey) parts.push(`Tracking key: \`${e.trackingKey}\``);
   if (e.hashAttribute) parts.push(`Hash attribute: \`${e.hashAttribute}\``);
   if (e.project) parts.push(`Project: ${e.project}`);
-  if (e.owner) parts.push(`Owner: ${e.owner}`);
+  if (e.ownerEmail) {
+    parts.push(`Owner: ${e.ownerEmail}`);
+  } else if (e.owner) {
+    parts.push(`Owner: ${e.owner}`);
+  }
   if (e.tags?.length) parts.push(`Tags: ${e.tags.join(", ")}`);
 
   // Linked features

--- a/src/tools/experiments/experiment-summary.ts
+++ b/src/tools/experiments/experiment-summary.ts
@@ -20,6 +20,7 @@ interface ExperimentCard {
   project: string;
   tags: string[];
   owner: string;
+  ownerEmail?: string;
   type: "standard" | "multi-armed-bandit";
 
   primaryMetric: {
@@ -342,6 +343,7 @@ async function buildExperimentStats(
       project: exp.project || "",
       tags: exp.tags || [],
       owner: exp.owner || "",
+      ownerEmail: exp.ownerEmail,
       type: expType,
       primaryMetric: primaryMetricResult
         ? {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,6 +10,7 @@ export type Experiment = {
   project: string;
   tags?: string[];
   owner?: string;
+  ownerEmail?: string;
   resultSummary: {
     status: string;
     winner: string;


### PR DESCRIPTION
## Description

The GrowthBook MCP server currently returns the user ID (`owner`) for experiments but does not include the creator's display name (`ownerEmail`). The REST API already returns `ownerEmail` (added in PR #5695), so the MCP server should surface this field to match.

## Changes

- **`format-responses.ts`**: `formatExperimentDetail` now shows `ownerEmail` when available, falling back to raw `owner` ID. `formatExperimentList` also includes owner info per experiment.
- **`types/types.ts`**: Added `ownerEmail?: string` to the `Experiment` type.
- **`api-types.d.ts`**: Added `ownerEmail?: string` to the `Experiment` schema (note: types are auto-generated, maintainer may want to re-run `npm run generate-api-types`).
- **`experiment-summary.ts`**: Added `ownerEmail` to `ExperimentCard` interface.

## Example output

Before:
```
Owner: u_abc123
```

After:
```
Owner: user@example.com
```

Fixes #6435
