### PR TITLE
Show experiment owner display name instead of raw userId

### DIFF
--- a/src/api-types.d.ts
+++ b/src/api-types.d.ts
@@ -2642,6 +2642,10 @@ export interface components {
             description: string;
             tags: string[];
             owner: string;
+            /** @description The email address of the owner, when the owner can be resolved to a known user. */
+            ownerEmail?: string;
+            /** @description The display name of the owner, when the owner can be resolved to a known user. */
+            ownerName?: string;
             archived: boolean;
             status: string;
             autoRefresh: boolean;

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -466,7 +466,10 @@ export function formatExperimentDetail(
   if (e.trackingKey) parts.push(`Tracking key: \`${e.trackingKey}\``);
   if (e.hashAttribute) parts.push(`Hash attribute: \`${e.hashAttribute}\``);
   if (e.project) parts.push(`Project: ${e.project}`);
-  if (e.owner) parts.push(`Owner: ${e.owner}`);
+  if (e.owner) {
+    const ownerDisplay = e.ownerName ?? e.ownerEmail ?? e.owner;
+    parts.push(`Owner: ${ownerDisplay}`);
+  }
   if (e.tags?.length) parts.push(`Tags: ${e.tags.join(", ")}`);
 
   // Linked features

--- a/src/tools/experiments/experiment-summary.ts
+++ b/src/tools/experiments/experiment-summary.ts
@@ -20,6 +20,8 @@ interface ExperimentCard {
   project: string;
   tags: string[];
   owner: string;
+  ownerEmail?: string;
+  ownerName?: string;
   type: "standard" | "multi-armed-bandit";
 
   primaryMetric: {
@@ -342,6 +344,8 @@ async function buildExperimentStats(
       project: exp.project || "",
       tags: exp.tags || [],
       owner: exp.owner || "",
+      ownerEmail: exp.ownerEmail,
+      ownerName: exp.ownerName,
       type: expType,
       primaryMetric: primaryMetricResult
         ? {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,6 +10,8 @@ export type Experiment = {
   project: string;
   tags?: string[];
   owner?: string;
+  ownerEmail?: string;
+  ownerName?: string;
   resultSummary: {
     status: string;
     winner: string;


### PR DESCRIPTION
## What changed

Uses the `ownerName` field on experiment API responses (falls back to
`ownerEmail`, then the raw `owner` userId, if unavailable) when displaying
experiment ownership.

- `src/types/types.ts` : added `ownerEmail?`/`ownerName?` to `Experiment`.
- `src/format-responses.ts` : `formatExperimentDetail` now shows
  `ownerName ?? ownerEmail ?? owner`.
- `src/tools/experiments/experiment-summary.ts` : `ExperimentCard` carries
  both new fields through summary/full mode output.
- `src/api-types.d.ts` : added `ownerEmail`/`ownerName` to the `Experiment`
  schema.

## Depends on

growthbook/growthbook#6469 — the backend needs to ship this field
before it'll actually appear in real API responses.

## Note on api-types.d.ts

This file is normally regenerated via `npm run generate-api-types` against
production. Since the backend PR above hasn't been merged/deployed yet,
I hand-patched just the two new fields onto the `Experiment` schema rather
than doing a full regeneration (a full regen against production right now
wouldn't include `ownerName`, and regenerating from a local dev backend
pulls in unrelated `/v1`-prefixed paths that don't match production yet).
Once the backend PR ships, this should get a clean `npm run generate-api-types`
run to replace this manual patch.

## Testing

- `npm run build` : passes.
- `npm test` : all existing tests pass (56/56).
- Verified `formatExperimentDetail` directly against a fake experiment
  object with `owner`/`ownerEmail`/`ownerName` set , confirmed it correctly
  prefers `ownerName` in the output.