### PR TITLE
Adds create_fact_table and create_fact_metric tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `create_fact_table` tool — create a fact table from SQL (data source, user id types, optional event name, projects, and tags), completing the read-only fact table tools
+- `create_fact_metric` tool — create a fact metric on an existing fact table for every metric type (proportion, retention, mean, quantile, ratio, dailyParticipation), including row filters, aggregate filters, and quantile settings. Cross-field rules documented by the API are checked before the request, so invalid input comes back as a list of fixes instead of a 400
+- Both creation tools accept `managedBy: "api"` to make a resource read-only in the GrowthBook UI, and tag what they create with `mcp`
 - `get_fact_table` tool — fetch a single fact table by id (columns, SQL, datasource, user id types) for analytics and metric configuration
 - `list_fact_tables` tool — list fact tables with pagination and optional project or data source filters; use ids for product analytics and fact metrics workflows
 - `create_metric_exploration` tool — chart metric data over time with configurable date ranges and chart types, returns visualization data and a link to view in GrowthBook

--- a/manifest.json
+++ b/manifest.json
@@ -85,12 +85,20 @@
       "description": "List metrics in GrowthBook. Metrics measure experiment success. Includes both fact metrics (modern) and legacy metrics."
     },
     {
+      "name": "create_fact_metric",
+      "description": "Create a fact metric on an existing fact table. Requires a name, a metricType (proportion, mean, ratio, quantile, retention, or dailyParticipation), and a numerator pointing at a fact table id. Ratio metrics need a denominator and quantile metrics need quantileSettings. Analysis settings such as conversion windows and priors inherit the organization defaults. Input problems are reported as a list before anything is sent to GrowthBook."
+    },
+    {
       "name": "list_fact_tables",
       "description": "List GrowthBook fact tables with optional filters by project or data source. Returns ids and datasource ids; use get_fact_table for full schema and SQL."
     },
     {
       "name": "get_fact_table",
       "description": "Fetch one fact table by id: datasource, user id types, full column objects as JSON (API keys only), and SQL. Omitted booleans on columns mean false. Use after list_fact_tables."
+    },
+    {
+      "name": "create_fact_table",
+      "description": "Create a fact table: the event-level SQL that fact metrics are built on. Requires a name, a data source id, the identifier columns the SQL returns (userIdTypes), and the SQL itself. GrowthBook parses the SQL to detect columns, so verify with get_fact_table afterwards."
     },
     {
       "name": "get_defaults",

--- a/src/api-type-helpers.ts
+++ b/src/api-type-helpers.ts
@@ -79,12 +79,16 @@ export type ListFactMetricsResponse =
   Paths["/fact-metrics"]["get"]["responses"][200]["content"]["application/json"];
 export type GetFactMetricResponse =
   Paths["/fact-metrics/{id}"]["get"]["responses"][200]["content"]["application/json"];
+export type CreateFactMetricResponse =
+  Paths["/fact-metrics"]["post"]["responses"][200]["content"]["application/json"];
 
 // Fact tables
 export type ListFactTablesResponse =
   Paths["/fact-tables"]["get"]["responses"][200]["content"]["application/json"];
 export type GetFactTableResponse =
   Paths["/fact-tables/{id}"]["get"]["responses"][200]["content"]["application/json"];
+export type CreateFactTableResponse =
+  Paths["/fact-tables"]["post"]["responses"][200]["content"]["application/json"];
 
 // Stale features
 export type GetStaleFeatureResponse =

--- a/src/format-responses.ts
+++ b/src/format-responses.ts
@@ -18,6 +18,8 @@ import type {
   GetFactMetricResponse,
   ListFactTablesResponse,
   GetFactTableResponse,
+  CreateFactTableResponse,
+  CreateFactMetricResponse,
   Feature,
   GetStaleFeatureResponse,
 } from "./api-type-helpers.js";
@@ -162,6 +164,32 @@ export function formatFactTableDetail(data: GetFactTableResponse): string {
     parts.push("");
     parts.push(
       `*(SQL truncated; ${sql.length - FACT_TABLE_SQL_MAX_CHARS} more characters in source.)*`
+    );
+  }
+
+  return parts.join("\n");
+}
+
+export function formatFactTableCreated(
+  data: CreateFactTableResponse,
+  appOrigin: string
+): string {
+  const t = data.factTable;
+  const id = t?.id || "unknown";
+  const link = generateLinkToGrowthBook(appOrigin, "fact-tables", id);
+
+  const parts = [
+    `**Fact table \`${id}\` created.**`,
+    `[View in GrowthBook](${link})`,
+    "",
+    "GrowthBook parses the SQL to detect columns. Use `get_fact_table` to confirm the columns were detected as expected.",
+    "Then use `create_fact_metric` with this fact table id to define a metric on top of it.",
+  ];
+
+  if (t?.managedBy === "api") {
+    parts.push("");
+    parts.push(
+      "*This fact table is managed by the API and cannot be edited in the GrowthBook UI.*"
     );
   }
 
@@ -622,6 +650,48 @@ export function formatMetricDetail(
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+export function formatFactMetricCreated(
+  data: CreateFactMetricResponse,
+  appOrigin: string
+): string {
+  const m = data.factMetric;
+  const id = m?.id || "unknown";
+  const link = generateLinkToGrowthBook(appOrigin, "fact-metrics", id);
+
+  const parts = [
+    `**Fact metric \`${id}\` created.**`,
+    `[View in GrowthBook](${link})`,
+    "",
+    "Analysis settings (conversion window, capping, priors, thresholds) use your organization defaults. Adjust them in the GrowthBook UI if this metric needs different ones.",
+    "Add the metric to an experiment to start measuring it.",
+  ];
+
+  if (m?.managedBy === "api") {
+    parts.push("");
+    parts.push(
+      "*This metric is managed by the API and cannot be edited in the GrowthBook UI.*"
+    );
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Formats the cross-field problems found before calling the API, so the agent
+ * gets every issue at once instead of one 400 response at a time.
+ */
+export function formatFactMetricValidationErrors(errors: string[]): string {
+  return [
+    `Cannot create this fact metric yet — ${errors.length} ${
+      errors.length === 1 ? "problem" : "problems"
+    } to fix:`,
+    "",
+    ...errors.map((e) => `- ${e}`),
+    "",
+    "Fix these and call `create_fact_metric` again. Nothing was sent to GrowthBook.",
+  ].join("\n");
 }
 
 // ─── Defaults ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ Key workflows:
 - Experiments: ALWAYS call get_defaults first, then create_experiment. Experiments are created as "draft" - users must launch in GrowthBook UI
 - Analysis: Use get_experiments with mode="summary" for quick insights
 - Product analytics: Use list_fact_tables to find fact table IDs, then get_fact_table for columns and SQL. Use get_metrics to find fact metric IDs. Use create_metric_exploration to chart one or more fact metrics on the same exploration (metricId or metrics[]), or create_fact_table_exploration for ad-hoc aggregates with one or more series (counts, distinct units, sums).
+- Metric setup: Use create_fact_table to define event-level SQL, then create_fact_metric on top of it. Check column names with get_fact_table before creating a metric
 
 All mutating tools require a fileExtension parameter for SDK integration guidance.`,
     capabilities: {
@@ -106,6 +107,8 @@ registerFactTableTools({
   server,
   baseApiUrl,
   apiKey,
+  appOrigin,
+  user,
 });
 
 registerProductAnalyticsTools({

--- a/src/tools/fact-schemas.ts
+++ b/src/tools/fact-schemas.ts
@@ -1,0 +1,374 @@
+import { z } from "zod";
+
+/**
+ * Shared input schemas, validation, and payload builders for the fact table and
+ * fact metric write tools.
+ *
+ * Design notes:
+ * - The Zod shapes below mirror the request bodies of `POST /fact-tables` and
+ *   `POST /fact-metrics`. They intentionally cover how a metric is *defined*
+ *   (type, numerator, denominator, filters, quantiles) and leave analysis
+ *   tuning (priors, regression adjustment, risk thresholds, conversion windows)
+ *   to the org defaults, which users adjust in the GrowthBook UI. This keeps
+ *   the tools small enough for an agent to use correctly.
+ * - `validateFactMetricInput` only enforces constraints the API documents
+ *   explicitly. Anything the API merely implies is left to the API, so the MCP
+ *   never rejects a request GrowthBook would have accepted.
+ */
+
+/** Row filter operators accepted by the fact metric API. */
+export const factRowFilterOperatorSchema = z.enum([
+  "=",
+  "!=",
+  ">",
+  "<",
+  ">=",
+  "<=",
+  "in",
+  "not_in",
+  "is_null",
+  "not_null",
+  "is_true",
+  "is_false",
+  "contains",
+  "not_contains",
+  "starts_with",
+  "ends_with",
+  "sql_expr",
+  "saved_filter",
+]);
+
+/** Operators that carry no comparison values. */
+const OPERATORS_WITHOUT_VALUES = new Set([
+  "is_null",
+  "not_null",
+  "is_true",
+  "is_false",
+]);
+
+/** Operators that do not target a single column. */
+const OPERATORS_WITHOUT_COLUMN = new Set(["sql_expr", "saved_filter"]);
+
+/** Metric types whose numerator must not specify a column. */
+const METRIC_TYPES_WITHOUT_NUMERATOR_COLUMN = new Set([
+  "proportion",
+  "dailyParticipation",
+]);
+
+/** Metric types that support aggregate filters. */
+const METRIC_TYPES_WITH_AGGREGATE_FILTER = new Set(["retention", "proportion"]);
+
+export const factRowFilterSchema = z.object({
+  operator: factRowFilterOperatorSchema.describe(
+    "Comparison operator applied to rows before aggregation."
+  ),
+  column: z
+    .string()
+    .optional()
+    .describe(
+      "Column to filter on. Required for every operator except sql_expr and saved_filter."
+    ),
+  values: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Values to compare against. Not required for is_null, not_null, is_true, and is_false."
+    ),
+});
+
+const factMetricColumnAggregationSchema = z
+  .enum(["sum", "max", "count distinct"])
+  .describe(
+    "How the column is aggregated per unit. Defaults to sum for numeric columns; string columns require 'count distinct'."
+  );
+
+export const factMetricNumeratorSchema = z.object({
+  factTableId: z
+    .string()
+    .describe("Fact table id (use list_fact_tables to find one)."),
+  column: z
+    .string()
+    .optional()
+    .describe(
+      "Column to aggregate, or a special value: '$$count', '$$distinctUsers', or '$$distinctDates'. Must be omitted for proportion and dailyParticipation metrics."
+    ),
+  aggregation: factMetricColumnAggregationSchema.optional(),
+  rowFilters: z
+    .array(factRowFilterSchema)
+    .optional()
+    .describe("Filters applied to fact table rows before aggregation."),
+  aggregateFilterColumn: z
+    .string()
+    .optional()
+    .describe(
+      "Column used to filter units after aggregation ('$$count' or a numeric column). Only for retention and proportion metrics, and requires aggregateFilter."
+    ),
+  aggregateFilter: z
+    .string()
+    .optional()
+    .describe(
+      "Comparison applied after aggregation, e.g. '>= 2'. Requires aggregateFilterColumn."
+    ),
+});
+
+export const factMetricDenominatorSchema = z.object({
+  factTableId: z.string().describe("Fact table id for the denominator."),
+  column: z
+    .string()
+    .describe(
+      "Column to aggregate, or a special value: '$$count', '$$distinctUsers', or '$$distinctDates'."
+    ),
+  aggregation: factMetricColumnAggregationSchema.optional(),
+  rowFilters: z
+    .array(factRowFilterSchema)
+    .optional()
+    .describe("Filters applied to denominator rows before aggregation."),
+});
+
+export const factMetricQuantileSettingsSchema = z.object({
+  type: z
+    .enum(["event", "unit"])
+    .describe(
+      "Whether the quantile is computed over raw event values or over per-unit aggregates."
+    ),
+  quantile: z
+    .number()
+    .gt(0)
+    .lt(1)
+    .describe("Quantile to compute, strictly between 0 and 1 (e.g. 0.95)."),
+  ignoreZeros: z
+    .boolean()
+    .describe("When true, zero values are excluded before computing."),
+});
+
+/** Input shape for `create_fact_table`. */
+export const createFactTableShape = {
+  name: z.string().describe("Display name of the fact table."),
+  datasource: z
+    .string()
+    .describe(
+      "Data source id the SQL runs against (use get_defaults to see the configured data source)."
+    ),
+  userIdTypes: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "Identifier columns returned by the SQL, e.g. ['user_id'] or ['anonymous_id', 'user_id']."
+    ),
+  sql: z
+    .string()
+    .describe(
+      "SQL returning one row per event, including the identifier columns and a timestamp column."
+    ),
+  description: z.string().optional().describe("What this fact table contains."),
+  eventName: z
+    .string()
+    .optional()
+    .describe("Event name used in SQL template variables."),
+  projects: z
+    .array(z.string())
+    .optional()
+    .describe("Project ids to scope this fact table to (use get_projects)."),
+  tags: z.array(z.string()).optional().describe("Tags to apply."),
+  managedBy: z
+    .literal("api")
+    .optional()
+    .describe(
+      "Set to 'api' to make this fact table read-only in the GrowthBook UI, so it can only be changed through the API. Leave unset for a table users can edit."
+    ),
+} as const;
+
+/** Input shape for `create_fact_metric`. */
+export const createFactMetricShape = {
+  name: z.string().describe("Display name of the metric."),
+  metricType: z
+    .enum([
+      "proportion",
+      "retention",
+      "mean",
+      "quantile",
+      "ratio",
+      "dailyParticipation",
+    ])
+    .describe(
+      "proportion: share of units with at least one matching row. mean: average of a column per unit. ratio: numerator divided by denominator. quantile: percentile of values. retention and dailyParticipation: engagement over time."
+    ),
+  numerator: factMetricNumeratorSchema.describe(
+    "What the metric measures. Required for every metric type."
+  ),
+  denominator: factMetricDenominatorSchema
+    .optional()
+    .describe("Required for ratio metrics, and rejected for every other type."),
+  quantileSettings: factMetricQuantileSettingsSchema
+    .optional()
+    .describe("Required for quantile metrics."),
+  inverse: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set to true when a decrease is an improvement, e.g. bounce rate."
+    ),
+  description: z.string().optional().describe("What this metric measures."),
+  projects: z
+    .array(z.string())
+    .optional()
+    .describe("Project ids to scope this metric to (use get_projects)."),
+  tags: z.array(z.string()).optional().describe("Tags to apply."),
+  displayAsPercentage: z
+    .boolean()
+    .optional()
+    .describe("Display the metric value as a percentage."),
+  managedBy: z
+    .literal("api")
+    .optional()
+    .describe(
+      "Set to 'api' to make this metric read-only in the GrowthBook UI, so it can only be changed through the API. Leave unset for a metric users can edit."
+    ),
+} as const;
+
+export type FactTableInput = z.infer<z.ZodObject<typeof createFactTableShape>>;
+export type FactMetricInput = z.infer<z.ZodObject<typeof createFactMetricShape>>;
+type FactMetricColumnRef =
+  | FactMetricInput["numerator"]
+  | NonNullable<FactMetricInput["denominator"]>;
+
+/** Always tag MCP-created resources so they can be found later. */
+const MCP_TAG = "mcp";
+
+function withMcpTag(tags?: string[]): string[] {
+  if (!tags?.length) return [MCP_TAG];
+  return tags.includes(MCP_TAG) ? tags : [...tags, MCP_TAG];
+}
+
+/** Drops keys whose value is undefined, keeping explicit `false` and `0`. */
+function omitUndefined<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined)
+  ) as T;
+}
+
+function validateRowFilters(
+  ref: FactMetricColumnRef,
+  path: "numerator" | "denominator"
+): string[] {
+  const errors: string[] = [];
+
+  ref.rowFilters?.forEach((filter, index) => {
+    const at = `${path}.rowFilters[${index}]`;
+
+    if (!OPERATORS_WITHOUT_VALUES.has(filter.operator) && !filter.values?.length) {
+      errors.push(
+        `${at}: operator '${filter.operator}' requires 'values'. Only is_null, not_null, is_true, and is_false take no values.`
+      );
+    }
+
+    if (!OPERATORS_WITHOUT_COLUMN.has(filter.operator) && !filter.column) {
+      errors.push(
+        `${at}: operator '${filter.operator}' requires a 'column'. Only sql_expr and saved_filter take none. Use get_fact_table to list valid column names.`
+      );
+    }
+  });
+
+  return errors;
+}
+
+/**
+ * Checks the cross-field rules the GrowthBook API documents for fact metrics.
+ * Returns one human-readable message per problem, so an agent can fix
+ * everything in a single pass instead of discovering issues one 400 at a time.
+ */
+export function validateFactMetricInput(input: FactMetricInput): string[] {
+  const errors: string[] = [];
+  const { metricType, numerator, denominator, quantileSettings } = input;
+
+  if (
+    METRIC_TYPES_WITHOUT_NUMERATOR_COLUMN.has(metricType) &&
+    numerator.column
+  ) {
+    errors.push(
+      `numerator.column must be empty for '${metricType}' metrics, which count units with at least one matching row rather than aggregating a column. Use rowFilters to narrow which rows count.`
+    );
+  }
+
+  if (metricType === "ratio" && !denominator) {
+    errors.push(
+      "denominator is required when metricType is 'ratio'. Provide the fact table and column to divide by."
+    );
+  }
+
+  if (metricType !== "ratio" && denominator) {
+    errors.push(
+      `denominator is only allowed when metricType is 'ratio' (got '${metricType}').`
+    );
+  }
+
+  if (metricType === "quantile" && !quantileSettings) {
+    errors.push(
+      "quantileSettings is required when metricType is 'quantile'. Provide type ('event' or 'unit'), quantile (0-1), and ignoreZeros."
+    );
+  }
+
+  const hasAggregateFilterColumn = Boolean(numerator.aggregateFilterColumn);
+  const hasAggregateFilter = Boolean(numerator.aggregateFilter);
+
+  if (hasAggregateFilterColumn !== hasAggregateFilter) {
+    errors.push(
+      "numerator.aggregateFilterColumn and numerator.aggregateFilter must be set together, e.g. column '$$count' with filter '>= 2'."
+    );
+  } else if (
+    hasAggregateFilterColumn &&
+    !METRIC_TYPES_WITH_AGGREGATE_FILTER.has(metricType)
+  ) {
+    errors.push(
+      `numerator.aggregateFilter is only supported for retention and proportion metrics (got '${metricType}').`
+    );
+  }
+
+  errors.push(...validateRowFilters(numerator, "numerator"));
+  if (denominator) {
+    errors.push(...validateRowFilters(denominator, "denominator"));
+  }
+
+  return errors;
+}
+
+/** Builds the `POST /fact-tables` request body. */
+export function buildFactTablePayload(
+  input: FactTableInput,
+  owner: string
+): Record<string, unknown> {
+  return omitUndefined({
+    name: input.name,
+    datasource: input.datasource,
+    userIdTypes: input.userIdTypes,
+    sql: input.sql,
+    owner,
+    tags: withMcpTag(input.tags),
+    description: input.description,
+    eventName: input.eventName,
+    projects: input.projects,
+    managedBy: input.managedBy,
+  });
+}
+
+/** Builds the `POST /fact-metrics` request body. */
+export function buildFactMetricPayload(
+  input: FactMetricInput,
+  owner: string
+): Record<string, unknown> {
+  return omitUndefined({
+    name: input.name,
+    metricType: input.metricType,
+    numerator: input.numerator,
+    owner,
+    tags: withMcpTag(input.tags),
+    // The API only accepts a denominator on ratio metrics.
+    denominator: input.metricType === "ratio" ? input.denominator : undefined,
+    quantileSettings: input.quantileSettings,
+    inverse: input.inverse,
+    description: input.description,
+    projects: input.projects,
+    displayAsPercentage: input.displayAsPercentage,
+    managedBy: input.managedBy,
+  });
+}

--- a/src/tools/fact-tables.ts
+++ b/src/tools/fact-tables.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  type BaseToolsInterface,
+  type ExtendedToolsInterface,
   fetchWithPagination,
   fetchWithRateLimit,
   buildHeaders,
@@ -10,19 +10,24 @@ import {
 import type {
   ListFactTablesResponse,
   GetFactTableResponse,
+  CreateFactTableResponse,
 } from "../api-type-helpers.js";
 import {
   formatFactTablesList,
   formatFactTableDetail,
+  formatFactTableCreated,
   formatApiError,
 } from "../format-responses.js";
+import { buildFactTablePayload, createFactTableShape } from "./fact-schemas.js";
 
-interface FactTableTools extends BaseToolsInterface {}
+interface FactTableTools extends ExtendedToolsInterface {}
 
 export function registerFactTableTools({
   server,
   baseApiUrl,
   apiKey,
+  appOrigin,
+  user,
 }: FactTableTools) {
   server.registerTool(
     "list_fact_tables",
@@ -137,6 +142,58 @@ export function registerFactTableTools({
           formatApiError(error, `fetching fact table '${factTableId}'`, [
             "Check the fact table id — use list_fact_tables to list valid ids.",
             "Ensure your GB_API_KEY can read fact tables.",
+          ])
+        );
+      }
+    }
+  );
+
+  /**
+   * Tool: create_fact_table
+   */
+  server.registerTool(
+    "create_fact_table",
+    {
+      title: "Create Fact Table",
+      description:
+        "Creates a GrowthBook fact table: the event-level SQL that fact metrics are built on. " +
+        "Requires a name, a data source id, the identifier columns the SQL returns (userIdTypes), and the SQL itself. " +
+        "Use `get_defaults` to find the data source id and `get_projects` to scope the table to a project. " +
+        "The SQL should return one row per event, including the identifier column(s) and a timestamp column. " +
+        "GrowthBook parses the SQL to detect columns, so verify with `get_fact_table` afterwards. " +
+        "Then use `create_fact_metric` to define metrics on top of it.",
+      inputSchema: createFactTableShape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (input) => {
+      try {
+        const res = await fetchWithRateLimit(`${baseApiUrl}/api/v1/fact-tables`, {
+          method: "POST",
+          headers: buildHeaders(apiKey),
+          body: JSON.stringify(buildFactTablePayload(input, user)),
+        });
+
+        await handleResNotOk(res);
+        const data = (await res.json()) as CreateFactTableResponse;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatFactTableCreated(data, appOrigin),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(error, `creating fact table '${input.name}'`, [
+            "Verify the datasource id — use get_defaults to see the configured data source.",
+            "Check that the SQL runs against that data source and returns every column listed in userIdTypes.",
+            "If scoping to a project, verify the project id with get_projects.",
           ])
         );
       }

--- a/src/tools/metrics.ts
+++ b/src/tools/metrics.ts
@@ -12,8 +12,20 @@ import type {
   ListFactMetricsResponse,
   GetMetricResponse,
   GetFactMetricResponse,
+  CreateFactMetricResponse,
 } from "../api-type-helpers.js";
-import { formatMetricsList, formatMetricDetail, formatApiError } from "../format-responses.js";
+import {
+  formatMetricsList,
+  formatMetricDetail,
+  formatFactMetricCreated,
+  formatFactMetricValidationErrors,
+  formatApiError,
+} from "../format-responses.js";
+import {
+  buildFactMetricPayload,
+  createFactMetricShape,
+  validateFactMetricInput,
+} from "./fact-schemas.js";
 
 interface MetricsTools extends ExtendedToolsInterface {}
 
@@ -22,6 +34,7 @@ export function registerMetricsTools({
   baseApiUrl,
   apiKey,
   appOrigin,
+  user,
 }: MetricsTools) {
   /**
    * Tool: get_metrics
@@ -131,6 +144,73 @@ export function registerMetricsTools({
         throw new Error(formatApiError(error, "fetching metrics", [
           "Check that your GB_API_KEY has permission to read metrics.",
         ]));
+      }
+    }
+  );
+
+  /**
+   * Tool: create_fact_metric
+   */
+  server.registerTool(
+    "create_fact_metric",
+    {
+      title: "Create Fact Metric",
+      description:
+        "Creates a fact metric on an existing fact table. Requires a name, a metricType, and a numerator pointing at a fact table id — use `list_fact_tables` to find the id and `get_fact_table` to check column names. " +
+        "Pick the metricType from what you are measuring: `proportion` for the share of units that did something (leave numerator.column empty), `mean` for the average of a column per unit, " +
+        "`ratio` for one aggregate divided by another (requires a denominator), `quantile` for a percentile (requires quantileSettings), and `retention` or `dailyParticipation` for engagement over time. " +
+        "Set `inverse` when a decrease is an improvement, such as bounce rate. " +
+        "Analysis settings (conversion windows, capping, priors, risk thresholds) are not set here — the metric inherits your organization defaults and can be tuned in the GrowthBook UI. " +
+        "Input problems are reported back as a list before anything is sent to GrowthBook.",
+      inputSchema: createFactMetricShape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (input) => {
+      const validationErrors = validateFactMetricInput(input);
+      if (validationErrors.length > 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatFactMetricValidationErrors(validationErrors),
+            },
+          ],
+        };
+      }
+
+      try {
+        const res = await fetchWithRateLimit(
+          `${baseApiUrl}/api/v1/fact-metrics`,
+          {
+            method: "POST",
+            headers: buildHeaders(apiKey),
+            body: JSON.stringify(buildFactMetricPayload(input, user)),
+          }
+        );
+
+        await handleResNotOk(res);
+        const data = (await res.json()) as CreateFactMetricResponse;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatFactMetricCreated(data, appOrigin),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          formatApiError(error, `creating fact metric '${input.name}'`, [
+            "Verify the fact table id — use list_fact_tables to list valid ids.",
+            "Verify column names against get_fact_table, including special values like '$$count' and '$$distinctUsers'.",
+            "If scoping to a project, verify the project id with get_projects.",
+          ])
+        );
       }
     }
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -503,7 +503,8 @@ export function generateLinkToGrowthBook(
     | "project"
     | "sdk-connection"
     | "metric"
-    | "fact-metrics",
+    | "fact-metrics"
+    | "fact-tables",
   id: string
 ) {
   return `${appOrigin}/${resource}/${id}`;

--- a/test/tools/fact-schemas.test.ts
+++ b/test/tools/fact-schemas.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFactMetricPayload,
+  buildFactTablePayload,
+  validateFactMetricInput,
+} from "../../src/tools/fact-schemas.js";
+
+const owner = "u@example.com";
+
+describe("buildFactTablePayload", () => {
+  it("sets the owner from the configured GrowthBook user", () => {
+    const payload = buildFactTablePayload(
+      {
+        name: "Orders",
+        datasource: "ds_1",
+        userIdTypes: ["id"],
+        sql: "SELECT * FROM orders",
+      },
+      owner
+    );
+
+    expect(payload.owner).toBe("u@example.com");
+  });
+
+  it("tags created fact tables with 'mcp' for traceability", () => {
+    const payload = buildFactTablePayload(
+      {
+        name: "Orders",
+        datasource: "ds_1",
+        userIdTypes: ["id"],
+        sql: "SELECT * FROM orders",
+      },
+      owner
+    );
+
+    expect(payload.tags).toEqual(["mcp"]);
+  });
+
+  it("keeps caller tags and appends 'mcp' without duplicating it", () => {
+    const payload = buildFactTablePayload(
+      {
+        name: "Orders",
+        datasource: "ds_1",
+        userIdTypes: ["id"],
+        sql: "SELECT * FROM orders",
+        tags: ["revenue", "mcp"],
+      },
+      owner
+    );
+
+    expect(payload.tags).toEqual(["revenue", "mcp"]);
+  });
+
+  it("omits optional keys that were not provided", () => {
+    const payload = buildFactTablePayload(
+      {
+        name: "Orders",
+        datasource: "ds_1",
+        userIdTypes: ["id"],
+        sql: "SELECT * FROM orders",
+      },
+      owner
+    );
+
+    expect(payload).not.toHaveProperty("description");
+    expect(payload).not.toHaveProperty("eventName");
+    expect(payload).not.toHaveProperty("projects");
+    expect(payload).not.toHaveProperty("managedBy");
+  });
+
+  it("passes managedBy through so callers can lock a table to API management", () => {
+    const payload = buildFactTablePayload(
+      {
+        name: "Orders",
+        datasource: "ds_1",
+        userIdTypes: ["id"],
+        sql: "SELECT * FROM orders",
+        managedBy: "api",
+      },
+      owner
+    );
+
+    expect(payload.managedBy).toBe("api");
+  });
+});
+
+describe("validateFactMetricInput", () => {
+  const proportion = {
+    name: "Signup rate",
+    metricType: "proportion" as const,
+    numerator: { factTableId: "ftb_1" },
+  };
+
+  it("accepts a valid proportion metric", () => {
+    expect(validateFactMetricInput(proportion)).toEqual([]);
+  });
+
+  it("rejects a proportion metric that sets a numerator column", () => {
+    const errors = validateFactMetricInput({
+      ...proportion,
+      numerator: { factTableId: "ftb_1", column: "amount" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("numerator.column");
+    expect(errors[0]).toContain("proportion");
+  });
+
+  it("rejects a dailyParticipation metric that sets a numerator column", () => {
+    const errors = validateFactMetricInput({
+      name: "DAU",
+      metricType: "dailyParticipation",
+      numerator: { factTableId: "ftb_1", column: "amount" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("numerator.column");
+  });
+
+  it("requires a denominator for ratio metrics", () => {
+    const errors = validateFactMetricInput({
+      name: "Revenue per order",
+      metricType: "ratio",
+      numerator: { factTableId: "ftb_1", column: "amount" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("denominator");
+    expect(errors[0]).toContain("ratio");
+  });
+
+  it("accepts a ratio metric that provides a denominator", () => {
+    const errors = validateFactMetricInput({
+      name: "Revenue per order",
+      metricType: "ratio",
+      numerator: { factTableId: "ftb_1", column: "amount" },
+      denominator: { factTableId: "ftb_1", column: "$$count" },
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects a denominator on a non-ratio metric", () => {
+    const errors = validateFactMetricInput({
+      name: "Average order value",
+      metricType: "mean",
+      numerator: { factTableId: "ftb_1", column: "amount" },
+      denominator: { factTableId: "ftb_1", column: "$$count" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("denominator");
+  });
+
+  it("requires quantileSettings for quantile metrics", () => {
+    const errors = validateFactMetricInput({
+      name: "p95 latency",
+      metricType: "quantile",
+      numerator: { factTableId: "ftb_1", column: "duration_ms" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("quantileSettings");
+  });
+
+  it("accepts a quantile metric that provides quantileSettings", () => {
+    const errors = validateFactMetricInput({
+      name: "p95 latency",
+      metricType: "quantile",
+      numerator: { factTableId: "ftb_1", column: "duration_ms" },
+      quantileSettings: {
+        type: "event",
+        quantile: 0.95,
+        ignoreZeros: false,
+      },
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it("requires values on row filter operators that compare", () => {
+    const errors = validateFactMetricInput({
+      ...proportion,
+      numerator: {
+        factTableId: "ftb_1",
+        rowFilters: [{ operator: "=", column: "country" }],
+      },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("values");
+  });
+
+  it("does not require values on null and boolean row filter operators", () => {
+    const errors = validateFactMetricInput({
+      ...proportion,
+      numerator: {
+        factTableId: "ftb_1",
+        rowFilters: [{ operator: "is_null", column: "country" }],
+      },
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it("requires a column on row filter operators that target one", () => {
+    const errors = validateFactMetricInput({
+      ...proportion,
+      numerator: {
+        factTableId: "ftb_1",
+        rowFilters: [{ operator: "in", values: ["FR"] }],
+      },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("column");
+  });
+
+  it("does not require a column for sql_expr and saved_filter operators", () => {
+    const errors = validateFactMetricInput({
+      ...proportion,
+      numerator: {
+        factTableId: "ftb_1",
+        rowFilters: [{ operator: "sql_expr", values: ["amount > 0"] }],
+      },
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it("validates row filters on the denominator too", () => {
+    const errors = validateFactMetricInput({
+      name: "Revenue per order",
+      metricType: "ratio",
+      numerator: { factTableId: "ftb_1", column: "amount" },
+      denominator: {
+        factTableId: "ftb_1",
+        column: "$$count",
+        rowFilters: [{ operator: "=", column: "country" }],
+      },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("denominator");
+  });
+
+  it("requires aggregateFilter and aggregateFilterColumn together", () => {
+    const errors = validateFactMetricInput({
+      ...proportion,
+      numerator: {
+        factTableId: "ftb_1",
+        aggregateFilterColumn: "$$count",
+      },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("aggregateFilter");
+  });
+
+  it("only allows aggregate filters on retention and proportion metrics", () => {
+    const errors = validateFactMetricInput({
+      name: "Average order value",
+      metricType: "mean",
+      numerator: {
+        factTableId: "ftb_1",
+        column: "amount",
+        aggregateFilterColumn: "$$count",
+        aggregateFilter: ">= 2",
+      },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("aggregateFilter");
+  });
+
+  it("reports every problem at once so the agent can fix them in one pass", () => {
+    const errors = validateFactMetricInput({
+      name: "Broken",
+      metricType: "ratio",
+      numerator: {
+        factTableId: "ftb_1",
+        rowFilters: [{ operator: "=", column: "country" }],
+      },
+    });
+
+    expect(errors.length).toBeGreaterThan(1);
+  });
+});
+
+describe("buildFactMetricPayload", () => {
+  const meanMetric = {
+    name: "Average order value",
+    metricType: "mean" as const,
+    numerator: { factTableId: "ftb_1", column: "amount" },
+  };
+
+  it("sets the owner and the mcp tag", () => {
+    const payload = buildFactMetricPayload(meanMetric, owner);
+
+    expect(payload.owner).toBe("u@example.com");
+    expect(payload.tags).toEqual(["mcp"]);
+  });
+
+  it("passes the numerator through untouched", () => {
+    const payload = buildFactMetricPayload(
+      {
+        ...meanMetric,
+        numerator: {
+          factTableId: "ftb_1",
+          column: "amount",
+          aggregation: "sum",
+          rowFilters: [{ operator: "=", column: "country", values: ["FR"] }],
+        },
+      },
+      owner
+    );
+
+    expect(payload.numerator).toEqual({
+      factTableId: "ftb_1",
+      column: "amount",
+      aggregation: "sum",
+      rowFilters: [{ operator: "=", column: "country", values: ["FR"] }],
+    });
+  });
+
+  it("drops a denominator when the metric is not a ratio", () => {
+    const payload = buildFactMetricPayload(
+      {
+        ...meanMetric,
+        denominator: { factTableId: "ftb_1", column: "$$count" },
+      },
+      owner
+    );
+
+    expect(payload).not.toHaveProperty("denominator");
+  });
+
+  it("includes the denominator for ratio metrics", () => {
+    const payload = buildFactMetricPayload(
+      {
+        name: "Revenue per order",
+        metricType: "ratio",
+        numerator: { factTableId: "ftb_1", column: "amount" },
+        denominator: { factTableId: "ftb_1", column: "$$count" },
+      },
+      owner
+    );
+
+    expect(payload.denominator).toEqual({
+      factTableId: "ftb_1",
+      column: "$$count",
+    });
+  });
+
+  it("omits optional keys that were not provided", () => {
+    const payload = buildFactMetricPayload(meanMetric, owner);
+
+    expect(payload).not.toHaveProperty("description");
+    expect(payload).not.toHaveProperty("projects");
+    expect(payload).not.toHaveProperty("quantileSettings");
+    expect(payload).not.toHaveProperty("inverse");
+    expect(payload).not.toHaveProperty("managedBy");
+  });
+
+  it("keeps inverse when explicitly set to false", () => {
+    const payload = buildFactMetricPayload(
+      { ...meanMetric, inverse: false },
+      owner
+    );
+
+    expect(payload.inverse).toBe(false);
+  });
+});

--- a/test/tools/fact-write-tools.test.ts
+++ b/test/tools/fact-write-tools.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from "vitest";
+
+type RegisteredTool = {
+  name: string;
+  config: any;
+  handler: (args: any, extra?: any) => Promise<any>;
+};
+
+function makeServerCapture() {
+  const tools: RegisteredTool[] = [];
+  const server = {
+    registerTool: (
+      name: string,
+      config: any,
+      handler: (args: any, extra?: any) => Promise<any>
+    ) => {
+      tools.push({ name, config, handler });
+    },
+    server: {
+      notification: vi.fn(async () => {}),
+    },
+  };
+  return { server: server as any, tools };
+}
+
+function makeResponse(opts: { ok: boolean; status: number; json: any }) {
+  return {
+    ok: opts.ok,
+    status: opts.status,
+    statusText: "",
+    headers: new Headers(),
+    json: async () => opts.json,
+    text: async () => JSON.stringify(opts.json),
+  } as any as Response;
+}
+
+const config = {
+  baseApiUrl: "https://api.example.com",
+  apiKey: "key",
+  appOrigin: "https://app.example.com",
+  user: "u@example.com",
+};
+
+async function registerFactTableTools(server: any) {
+  const { registerFactTableTools } = await import(
+    "../../src/tools/fact-tables.js"
+  );
+  registerFactTableTools({ server, ...config });
+}
+
+async function registerMetricsTools(server: any) {
+  const { registerMetricsTools } = await import("../../src/tools/metrics.js");
+  registerMetricsTools({ server, ...config });
+}
+
+describe("create_fact_table", () => {
+  it("posts the fact table to the fact-tables endpoint with auth headers", async () => {
+    vi.useFakeTimers();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return makeResponse({
+        ok: true,
+        status: 200,
+        json: { factTable: { id: "ftb_1", name: "Orders" } },
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { server, tools } = makeServerCapture();
+    await registerFactTableTools(server);
+
+    const tool = tools.find((t) => t.name === "create_fact_table");
+    expect(tool).toBeTruthy();
+
+    const p = tool!.handler({
+      name: "Orders",
+      datasource: "ds_1",
+      userIdTypes: ["user_id"],
+      sql: "SELECT * FROM orders",
+    });
+    await vi.runAllTimersAsync();
+    await p;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://api.example.com/api/v1/fact-tables");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: "Bearer key",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+      name: "Orders",
+      datasource: "ds_1",
+      userIdTypes: ["user_id"],
+      sql: "SELECT * FROM orders",
+      owner: "u@example.com",
+      tags: ["mcp"],
+    });
+  });
+
+  it("returns a link to the created fact table", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        makeResponse({
+          ok: true,
+          status: 200,
+          json: { factTable: { id: "ftb_1", name: "Orders" } },
+        })
+      )
+    );
+
+    const { server, tools } = makeServerCapture();
+    await registerFactTableTools(server);
+
+    const p = tools
+      .find((t) => t.name === "create_fact_table")!
+      .handler({
+        name: "Orders",
+        datasource: "ds_1",
+        userIdTypes: ["user_id"],
+        sql: "SELECT * FROM orders",
+      });
+    await vi.runAllTimersAsync();
+    const res = await p;
+
+    expect(res.content[0].type).toBe("text");
+    expect(res.content[0].text).toContain("ftb_1");
+    expect(res.content[0].text).toContain(
+      "https://app.example.com/fact-tables/ftb_1"
+    );
+  });
+
+  it("explains how to recover when the API rejects the fact table", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 400,
+          json: { message: "Invalid datasource" },
+        })
+      )
+    );
+
+    const { server, tools } = makeServerCapture();
+    await registerFactTableTools(server);
+
+    const p = tools
+      .find((t) => t.name === "create_fact_table")!
+      .handler({
+        name: "Orders",
+        datasource: "nope",
+        userIdTypes: ["user_id"],
+        sql: "SELECT * FROM orders",
+      });
+    await vi.runAllTimersAsync();
+
+    await expect(p).rejects.toThrow(/creating fact table/i);
+    await expect(p).rejects.toThrow(/get_defaults/);
+  });
+
+  it("is registered as a non-destructive write tool", async () => {
+    const { server, tools } = makeServerCapture();
+    await registerFactTableTools(server);
+
+    const tool = tools.find((t) => t.name === "create_fact_table")!;
+    expect(tool.config.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+    });
+  });
+});
+
+describe("create_fact_metric", () => {
+  it("posts the fact metric to the fact-metrics endpoint", async () => {
+    vi.useFakeTimers();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return makeResponse({
+        ok: true,
+        status: 200,
+        json: { factMetric: { id: "fact__1", name: "Average order value" } },
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { server, tools } = makeServerCapture();
+    await registerMetricsTools(server);
+
+    const tool = tools.find((t) => t.name === "create_fact_metric");
+    expect(tool).toBeTruthy();
+
+    const p = tool!.handler({
+      name: "Average order value",
+      metricType: "mean",
+      numerator: { factTableId: "ftb_1", column: "amount" },
+    });
+    await vi.runAllTimersAsync();
+    const res = await p;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://api.example.com/api/v1/fact-metrics");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+      name: "Average order value",
+      metricType: "mean",
+      numerator: { factTableId: "ftb_1", column: "amount" },
+      owner: "u@example.com",
+      tags: ["mcp"],
+    });
+    expect(res.content[0].text).toContain(
+      "https://app.example.com/fact-metrics/fact__1"
+    );
+  });
+
+  it("reports invalid input without calling the API", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: {} })
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { server, tools } = makeServerCapture();
+    await registerMetricsTools(server);
+
+    const p = tools
+      .find((t) => t.name === "create_fact_metric")!
+      .handler({
+        name: "Revenue per order",
+        metricType: "ratio",
+        numerator: { factTableId: "ftb_1", column: "amount" },
+      });
+    await vi.runAllTimersAsync();
+    const res = await p;
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(res.content[0].text).toContain("denominator");
+  });
+
+  it("is registered as a non-destructive write tool", async () => {
+    const { server, tools } = makeServerCapture();
+    await registerMetricsTools(server);
+
+    const tool = tools.find((t) => t.name === "create_fact_metric")!;
+    expect(tool.config.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+    });
+  });
+
+  it("explains how to recover when the API rejects the metric", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 400,
+          json: { message: "Invalid fact table" },
+        })
+      )
+    );
+
+    const { server, tools } = makeServerCapture();
+    await registerMetricsTools(server);
+
+    const p = tools
+      .find((t) => t.name === "create_fact_metric")!
+      .handler({
+        name: "Average order value",
+        metricType: "mean",
+        numerator: { factTableId: "nope", column: "amount" },
+      });
+    await vi.runAllTimersAsync();
+
+    await expect(p).rejects.toThrow(/creating fact metric/i);
+    await expect(p).rejects.toThrow(/list_fact_tables/);
+  });
+});


### PR DESCRIPTION
## What

Adds two write tools that complete the fact table and metric surface:

- **`create_fact_table`** → `POST /fact-tables`
- **`create_fact_metric`** → `POST /fact-metrics`

Today `list_fact_tables`, `get_fact_table`, and `get_metrics` let an agent inspect definitions, but creating one means leaving the editor for the UI. The exploration tools can chart a metric that already exists — nothing can bring one into being. These two close that gap.

## Design decisions

**1. Metric definition, not analysis tuning.** `POST /fact-metrics` accepts ~25 fields. The schema exposes what defines the metric — `metricType`, `numerator`, `denominator`, `rowFilters`, aggregate filters, `quantileSettings`, `inverse`, `displayAsPercentage` — and deliberately omits the statistical knobs (`windowSettings`, `cappingSettings`, `priorSettings`, `regressionAdjustmentSettings`, `riskThreshold*`, `minSampleSize`, `targetMDE`, `minPercentChange`, `maxPercentChange`). Those inherit org defaults and are better tuned in the UI where users see their effect. This follows the "avoid modes, keep tools simple" guidance in `CLAUDE.md` — a 25-field tool is one an agent fills in wrong.

Happy to add the window/capping settings if you'd rather have them; it's an additive change to the shape.

**2. Pre-flight validation, but only of documented rules.** `create_fact_metric` checks the cross-field constraints the OpenAPI descriptions state explicitly:

| Rule | Source in the spec |
|---|---|
| `numerator.column` must be empty for `proportion` / `dailyParticipation` | *"Must be empty for proportion metrics and dailyParticipation metrics"* |
| `denominator` required for `ratio`, rejected otherwise | *"Only when metricType is 'ratio'"* |
| `quantileSettings` required for `quantile` | *"mandatory if metricType is 'quantile'"* |
| `rowFilters[].values` required except `is_null` / `not_null` / `is_true` / `is_false` | *"Not required for is_null, not_null, is_true, is_false operators"* |
| `rowFilters[].column` required except `sql_expr` / `saved_filter` | *"Required for all operators except sql_expr and saved_filter"* |
| `aggregateFilterColumn` + `aggregateFilter` set together, only on `retention` / `proportion` | *"Must specify aggregateFilter if using this"*, *"Only can be used with 'retention' and 'proportion' metrics"* |

The guiding constraint: **only rules the API documents explicitly are enforced.** Anything the API merely implies is left to the API, so the MCP can never reject a request GrowthBook would have accepted. Under-validating is safe; over-validating blocks legitimate calls.

All problems are returned at once, as a response rather than an error — per the `CLAUDE.md` note on handling missing params gracefully:

```
Cannot create this fact metric yet — 2 problems to fix:

- denominator is required when metricType is 'ratio'. Provide the fact table and column to divide by.
- numerator.rowFilters[0]: operator '=' requires 'values'. Only is_null, not_null, is_true, and is_false take no values.

Fix these and call `create_fact_metric` again. Nothing was sent to GrowthBook.
```

No API call is made in that case.

**3. Shared module for schemas and payloads.** `src/tools/fact-schemas.ts` holds the Zod shapes, the validation, and the payload builders — following the `exploration-schemas.ts` precedent. The tools stay thin, and the logic is unit-testable with no network. The row filter schema is defined independently of `explorationRowFilterSchema`: the operator lists happen to match today, but they belong to different endpoints and should be free to diverge.

**4. Conventions carried over.** Both tools tag what they create with `mcp` (like `create_feature_flag`) and set `owner` from `GB_EMAIL`. Both accept `managedBy: "api"` to make the resource read-only in the UI, which matters for teams keeping definitions in version control. The `managedBy` state is surfaced in the response so the agent tells the user the resource is no longer UI-editable.

## Tests

35 new tests, 91 total (was 56), all passing:

- `test/tools/fact-schemas.test.ts` — 27 tests: every validation rule accepted and rejected, payload construction, tag merging without duplicating `mcp`, `undefined` omission while keeping explicit `false`, denominator dropped on non-ratio types.
- `test/tools/fact-write-tools.test.ts` — 8 tests: URL, method, auth headers, exact request body, returned GrowthBook link, tool annotations, error paths carrying actionable suggestions, and the validation path proving `fetch` is never called.

Also smoke-tested against the built server over stdio: `tools/list` returns 24 tools with correct required fields and annotations, and a real `tools/call` with invalid input returns the guidance above while pointed at an unreachable API host.

`npm run build` and `npm test` both clean.

## Checklist from CLAUDE.md

- [x] Tools added under `src/tools/`
- [x] Formatters in `format-responses.ts` (`formatFactTableCreated`, `formatFactMetricCreated`, `formatFactMetricValidationErrors`) — no raw `JSON.stringify`
- [x] `manifest.json` entries
- [x] `CHANGELOG.md` under `[Unreleased] → Added`
- [x] Build and tests pass
- [ ] `docs/docs/integrations/mcp.mdx` — lives in the main `growthbook` repo, so it can't ride along in this PR. Ready-to-paste copy below; happy to open the companion PR.

<details>
<summary>Docs snippet for <code>mcp.mdx</code></summary>

**Fact Tables section:**

`create_fact_table` — Creates a fact table from SQL. Requires `name`, `datasource`, `userIdTypes`, and `sql`; optionally `description`, `eventName`, `projects`, `tags`, and `managedBy`. GrowthBook parses the SQL to detect columns, so confirm with `get_fact_table` afterwards.

**Metrics section:**

`create_fact_metric` — Creates a fact metric on an existing fact table. Requires `name`, `metricType` (`proportion`, `retention`, `mean`, `quantile`, `ratio`, `dailyParticipation`), and `numerator`. Ratio metrics require a `denominator`; quantile metrics require `quantileSettings`. Analysis settings such as conversion windows, capping, and priors inherit your organization defaults and can be tuned in the UI. Invalid combinations are reported as a list of fixes before any request is sent.

</details>

## Notes

Both endpoints exist well before current releases (verified against the `v4.3.0` spec), so this works on self-hosted instances too, not just Cloud.

Two natural follow-ups, deliberately left out to keep this reviewable: fact table filters (`POST /fact-tables/{id}/filters`) and `POST /bulk-import/facts` for creating a whole set from a modeling layer in one call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
