### PR TITLE
Split API tools into read vs write (2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-10
+
+### Breaking
+
+- Replaced `growthbook_call_api` with separate tools so clients can honor read vs write annotations (required for Anthropic Connectors Directory review):
+  - `growthbook_api_read` — GET only (`readOnlyHint: true`)
+  - `growthbook_api_write` — POST/PUT/PATCH/DELETE (`destructiveHint: true`)
+- Removed soft “confirm mutating methods with the user” guidance from tool descriptions and server instructions; confirmation is left to client annotation handling
+
+### Changed
+
+- Skill bridge note and server instructions map `gb-call GET` → `growthbook_api_read` and mutating methods → `growthbook_api_write`
+- Freeform API tool descriptions link to the [GrowthBook REST API docs](https://docs.growthbook.io/api)
+
+### Migration
+
+1. Replace `growthbook_call_api` with `growthbook_api_read` (GET) or `growthbook_api_write` (POST/PUT/PATCH/DELETE).
+2. Point clients at `@growthbook/mcp@2.1.0`.
+
 ## [2.0.0] - 2026-07-30
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # GrowthBook MCP Thin
 
-A thin MCP server for GrowthBook with three tools:
+A thin MCP server for GrowthBook with four tools:
 
 | Tool | Purpose |
 |------|---------|
 | `growthbook_list_skills` | List bundled GrowthBook agent skills (name + description) |
 | `growthbook_read_skill` | Return the full skill markdown (workflow + guardrails) |
-| `growthbook_call_api` | Authenticated REST passthrough to the GrowthBook API |
+| `growthbook_api_read` | Authenticated GET passthrough to the GrowthBook API |
+| `growthbook_api_write` | Authenticated POST/PUT/PATCH/DELETE passthrough |
 
-Competence lives in the [skills](https://github.com/growthbook/skills) repo and is **bundled at build time**. Capability is a generic `growthbook_call_api` tool — no per-endpoint formatters. The tool description asks agents to confirm mutating methods (POST/PUT/PATCH/DELETE) with the user unless already instructed.
+Competence lives in the [skills](https://github.com/growthbook/skills) repo and is **bundled at build time**. Capability is split into read vs write API tools (no per-endpoint formatters) so clients can honor `readOnlyHint` / `destructiveHint` correctly.
 
-Tools are prefixed with `growthbook_` so they stay unambiguous when a client has multiple MCP servers loaded — an agent should never mistake `growthbook_call_api` for a generic API caller.
+Tools are prefixed with `growthbook_` so they stay unambiguous when a client has multiple MCP servers loaded.
 
 ## Install / run
 
@@ -64,12 +65,12 @@ GB_MCP_TRANSPORT=http GB_API_URL=http://localhost:3100 GB_MCP_PORT=3333 npm star
 ```
 
 Clients connect to:
-- `http://127.0.0.1:3333/mcp` — full (skills + API)
-- `http://127.0.0.1:3333/mcp/api` — capability-only (`growthbook_call_api`)
+- `http://127.0.0.1:3333/mcp` — full (skills + API read/write)
+- `http://127.0.0.1:3333/mcp/api` — capability-only (`growthbook_api_read` + `growthbook_api_write`)
 
 Unauthenticated requests receive `401` with `WWW-Authenticate` pointing at `/.well-known/oauth-protected-resource`, which advertises the GrowthBook Authorization Server.
 
-Before handling MCP, the server probes GrowthBook REST (`GET /api/v1/`) with the bearer. A `401` from that probe (or later from `growthbook_call_api`) yields HTTP `401` with `error="invalid_token"` so the MCP client can refresh — instead of surfacing `"This API key has expired"` as a tool error. A `403` is treated as an accepted bearer (permission denied ≠ invalid token) so clients are not forced into a refresh loop.
+Before handling MCP, the server probes GrowthBook REST (`GET /api/v1/`) with the bearer. A `401` from that probe (or later from an API tool) yields HTTP `401` with `error="invalid_token"` so the MCP client can refresh — instead of surfacing `"This API key has expired"` as a tool error. A `403` is treated as an accepted bearer (permission denied ≠ invalid token) so clients are not forced into a refresh loop.
 
 ### Capability-only mode
 
@@ -87,8 +88,8 @@ Before handling MCP, the server probes GrowthBook REST (`GET /api/v1/`) with the
 
 | Path | Tools |
 |------|--------|
-| `/mcp` | `growthbook_list_skills`, `growthbook_read_skill`, `growthbook_call_api` (unless `GB_SKILLS_ENABLED=false`) |
-| `/mcp/api` | `growthbook_call_api` only |
+| `/mcp` | `growthbook_list_skills`, `growthbook_read_skill`, `growthbook_api_read`, `growthbook_api_write` (unless `GB_SKILLS_ENABLED=false`) |
+| `/mcp/api` | `growthbook_api_read`, `growthbook_api_write` only |
 
 **stdio / process-wide:** set env so skills are never registered:
 
@@ -99,7 +100,7 @@ Before handling MCP, the server probes GrowthBook REST (`GET /api/v1/`) with the
 }
 ```
 
-When skills are disabled, only `growthbook_call_api` is registered. `growthbook_list_skills` and `growthbook_read_skill` are not exposed.
+When skills are disabled, only the API read/write tools are registered. `growthbook_list_skills` and `growthbook_read_skill` are not exposed.
 
 ## How skills are bundled
 
@@ -116,7 +117,7 @@ Source path resolution:
 
 The skills repo stays the source of truth — this package never forks skill content.
 
-## Using skills with `growthbook_call_api`
+## Using skills with the API tools
 
 Bundled skills still show workflows as:
 
@@ -125,21 +126,22 @@ gb-call GET /api/v1/projects
 gb-call POST /api/v2/features ./payload.json
 ```
 
-This MCP server does **not** shell out to `gb-call`. When a skill shows that pattern, call the `growthbook_call_api` tool with the same method, path, and optional JSON body string. Server instructions and `growthbook_read_skill` output include this bridge note.
+This MCP server does **not** shell out to `gb-call`. Map `GET` → `growthbook_api_read` and `POST`/`PUT`/`PATCH`/`DELETE` → `growthbook_api_write` with the same path and optional JSON body string. Server instructions and `growthbook_read_skill` output include this bridge note.
 
 ## Tools detail
 
-### `growthbook_call_api`
+### `growthbook_api_read` / `growthbook_api_write`
 
 ```json
-{ "method": "GET", "path": "/api/v1/projects" }
+{ "path": "/api/v1/projects" }
 { "method": "POST", "path": "/api/v2/features", "body": "{\"id\":\"my-flag\",...}" }
 ```
 
-- Methods: `GET` | `POST` | `PUT` | `PATCH` | `DELETE`
+- Read: GET only (`readOnlyHint: true`)
+- Write: `POST` | `PUT` | `PATCH` | `DELETE` (`destructiveHint: true`)
 - Returns raw response body on 2xx
 - On non-2xx, returns an actionable error (`isError: true`) covering auth failures, self-hosted 404 hints, and rate limits
-- Tool description + server instructions tell the agent to confirm POST/PUT/PATCH/DELETE with the user unless already instructed (soft guidance, not a hard gate)
+- Freeform paths target the [GrowthBook REST API](https://docs.growthbook.io/api)
 
 ### `growthbook_list_skills` / `growthbook_read_skill`
 
@@ -156,7 +158,7 @@ npm start
 
 ## Standalone HTTP mode
 
-By default the server runs over stdio. Set `GB_MCP_TRANSPORT=http` to run it as a standalone HTTP server that exposes MCP at `/mcp` (skills + `growthbook_call_api`) and `/mcp/api` (capability-only), behind an OAuth 2.0 protected-resource surface (RFC 9728 metadata + RFC 6750 `WWW-Authenticate`).
+By default the server runs over stdio. Set `GB_MCP_TRANSPORT=http` to run it as a standalone HTTP server that exposes MCP at `/mcp` (skills + API tools) and `/mcp/api` (capability-only), behind an OAuth 2.0 protected-resource surface (RFC 9728 metadata + RFC 6750 `WWW-Authenticate`).
 
 - `GB_MCP_URL` (**required** in HTTP mode) — the server's public base URL. It is stamped into the OAuth resource (audience) and the protected-resource metadata, so it is never derived from request headers. The server refuses to start without it.
 - `GB_MCP_PORT` (default `3333`) and `GB_MCP_HOST` (default `127.0.0.1`).

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": "0.2",
   "name": "GrowthBook",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Thin MCP server for GrowthBook — skill loader + authenticated API passthrough",
-  "long_description": "A thin GrowthBook MCP server with three tools: growthbook_list_skills and growthbook_read_skill (bundled GrowthBook agent skills) plus growthbook_call_api (authenticated REST passthrough). Skills can be disabled so clients can use only the API capability with their own workflows.",
+  "long_description": "A thin GrowthBook MCP server with four tools: growthbook_list_skills and growthbook_read_skill (bundled GrowthBook agent skills) plus growthbook_api_read and growthbook_api_write (authenticated REST passthrough, split for read vs write). Skills can be disabled so clients can use only the API capability with their own workflows.",
   "author": {
     "name": "GrowthBook",
     "email": "support@growthbook.io"
@@ -15,7 +15,9 @@
     "entry_point": "server/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/server/index.js"],
+      "args": [
+        "${__dirname}/server/index.js"
+      ],
       "env": {
         "GB_API_KEY": "${user_config.GB_API_KEY}",
         "GB_API_URL": "${user_config.GB_API_URL}",
@@ -33,8 +35,12 @@
       "description": "Return the full markdown content of a GrowthBook skill by name."
     },
     {
-      "name": "growthbook_call_api",
-      "description": "Make an authenticated HTTP request to the GrowthBook REST API. Confirm mutating methods with the user unless already instructed."
+      "name": "growthbook_api_read",
+      "description": "Make an authenticated GET request to the GrowthBook REST API. See https://docs.growthbook.io/api"
+    },
+    {
+      "name": "growthbook_api_write",
+      "description": "Make an authenticated POST/PUT/PATCH/DELETE request to the GrowthBook REST API. See https://docs.growthbook.io/api"
     }
   ],
   "user_config": {
@@ -56,7 +62,7 @@
     "GB_SKILLS_ENABLED": {
       "type": "string",
       "title": "Enable bundled skills",
-      "description": "Set to false to disable growthbook_list_skills/growthbook_read_skill and use only growthbook_call_api (capability-only mode).",
+      "description": "Set to false to disable growthbook_list_skills/growthbook_read_skill and use only the API read/write tools (capability-only mode).",
       "required": false,
       "sensitive": false,
       "default": "true"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@growthbook/mcp",
   "mcpName": "io.github.growthbook/growthbook-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Thin MCP server for GrowthBook — skill loader + authenticated API passthrough",
   "access": "public",
   "homepage": "https://github.com/growthbook/growthbook-mcp",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/growthbook/growthbook-mcp",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@growthbook/mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api.ts
+++ b/src/api.ts
@@ -388,7 +388,7 @@ export async function checkBearerWithGrowthBook(
   return "unavailable";
 }
 
-/** Drop cached validity (e.g. after an upstream 401 on growthbook_call_api). */
+/** Drop cached validity (e.g. after an upstream 401 on an API tool call). */
 export function invalidateBearerCache(token: string): void {
   bearerValidUntil.delete(token);
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -2,14 +2,14 @@
  * Streamable HTTP transport + OAuth resource-server surface for the thin MCP.
  *
  * Paths:
- * - POST /mcp      — full server (skills + growthbook_call_api), unless GB_SKILLS_ENABLED=false
- * - POST /mcp/api  — capability-only (growthbook_call_api only)
+ * - POST /mcp      — full server (skills + API read/write tools), unless GB_SKILLS_ENABLED=false
+ * - POST /mcp/api  — capability-only (growthbook_api_read + growthbook_api_write)
  *
  * - Serves /.well-known/oauth-protected-resource (RFC 9728) pointing at the GB AS
  * - Requires Bearer; validates it against GrowthBook REST so expired/revoked
  *   tokens get HTTP 401 + WWW-Authenticate (RFC 6750 invalid_token) and the
  *   MCP client can refresh — not a tool-level "API key has expired" string
- * - Threads the bearer into growthbook_call_api via AsyncLocalStorage (transparent pass-through)
+ * - Threads the bearer into API tools via AsyncLocalStorage (transparent pass-through)
  */
 
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -25,7 +25,7 @@ import {
 } from "./api.js";
 
 export type CreateServerOptions = {
-  /** When false, only growthbook_call_api is registered. */
+  /** When false, only growthbook_api_read / growthbook_api_write are registered. */
   skills?: boolean;
 };
 
@@ -194,7 +194,7 @@ function createMcpHttpApp(options: McpHttpAppOptions): Express {
     serverOptions: CreateServerOptions
   ) => {
     const bearer = (req as Request & { gbBearer?: string }).gbBearer || "";
-    // Thread the bearer into growthbook_call_api via ALS for this request.
+    // Thread the bearer into API tools via ALS for this request.
     await requestAuthStore.run({ bearer }, async () => {
       const server = createServer({ skills: serverOptions.skills });
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { areSkillsEnabled, getTransportMode } from "./api.js";
 import { startHttpServer, type CreateServerOptions } from "./http.js";
-import { registerCallApiTool, registerSkillTools } from "./tools.js";
+import { registerApiTools, registerSkillTools } from "./tools.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -34,23 +34,22 @@ function instructionsFor(skills: boolean): string {
 Tools:
 - growthbook_list_skills — discover available GrowthBook skills (name + description)
 - growthbook_read_skill — load a skill's full workflow and guardrails
-- growthbook_call_api — make an authenticated GrowthBook REST API request on the user's behalf
+- growthbook_api_read — authenticated GET against the GrowthBook REST API
+- growthbook_api_write — authenticated POST/PUT/PATCH/DELETE against the GrowthBook REST API
 
 Workflow:
 1. growthbook_list_skills (or growthbook_read_skill if you already know the skill name) to load competence.
 2. Follow the skill's steps. Skills show bash like \`gb-call <METHOD> <PATH> [body]\` —
-   translate each of those into a growthbook_call_api invocation with the same method, path, and optional JSON body string.
+   map GET to growthbook_api_read and POST/PUT/PATCH/DELETE to growthbook_api_write with the same path and optional JSON body string.
 3. Do not invent endpoints; prefer the paths listed in the skill.
-4. Before growthbook_call_api with POST/PUT/PATCH/DELETE, confirm with the user (method, path, body summary)
-   unless they already explicitly instructed that mutation. GET does not need confirmation.
 
 Skill content is the source of truth for GrowthBook task workflows and API footguns.
-growthbook_call_api is a dumb authenticated passthrough — it does not validate payloads.`
+growthbook_api_read / growthbook_api_write are dumb authenticated passthroughs — they do not validate payloads.`
     : `You are a helpful assistant that interacts with GrowthBook via a thin MCP server.
 
-Only the growthbook_call_api tool is available (capability-only mode — bundled skills are not exposed).
-Use growthbook_call_api to make authenticated GrowthBook REST API requests: method, path (e.g. /api/v1/projects), and optional JSON body.
-Before POST/PUT/PATCH/DELETE, confirm with the user unless they already explicitly instructed that mutation.
+Only the API tools are available (capability-only mode — bundled skills are not exposed):
+- growthbook_api_read — GET requests (path, e.g. /api/v1/projects)
+- growthbook_api_write — POST/PUT/PATCH/DELETE (method, path, optional JSON body)
 The client or user is expected to supply their own skill/workflow guidance.`;
 }
 
@@ -72,7 +71,7 @@ export function createServer(options: CreateServerOptions = {}): McpServer {
     }
   );
 
-  registerCallApiTool(server);
+  registerApiTools(server);
 
   if (skills) {
     registerSkillTools(server);

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -118,8 +118,7 @@ export function getSkill(name: string): Skill | undefined {
 
 /** Bridge note prepended when returning skill content via growthbook_read_skill. */
 export const GB_CALL_BRIDGE_NOTE = `> **MCP note:** This skill's workflow examples use \`gb-call <METHOD> <PATH> [body]\`.
-> In this MCP server, use the \`growthbook_call_api\` tool instead with the same method, path, and optional JSON body string.
-> Do not shell out to \`gb-call\`. Before POST/PUT/PATCH/DELETE, confirm with the user unless they already
-> explicitly instructed that mutation.
+> In this MCP server, map GET to \`growthbook_api_read\` and POST/PUT/PATCH/DELETE to \`growthbook_api_write\`
+> with the same path and optional JSON body string. Do not shell out to \`gb-call\`.
 
 `;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -8,25 +8,57 @@ import {
   loadSkills,
 } from "./skills.js";
 
-export function registerCallApiTool(server: McpServer) {
+const API_DOCS =
+  "https://docs.growthbook.io/api (OpenAPI: https://api.growthbook.io/api/v1/openapi.yaml)";
+
+export function registerApiTools(server: McpServer) {
   server.registerTool(
-    "growthbook_call_api",
+    "growthbook_api_read",
     {
-      title: "Call GrowthBook API",
+      title: "Read GrowthBook API",
       description:
-        "Make an authenticated HTTP request to the GrowthBook REST API on the user's behalf. " +
-        "Use method + path (+ optional JSON body) exactly as shown in skill workflows that mention gb-call. " +
-        "Paths typically start with /api/v1/ or /api/v2/. Returns the raw response body on success. " +
-        "IMPORTANT: Before POST, PUT, PATCH, or DELETE, confirm with the user (summarize method, path, and body) " +
-        "unless they have already explicitly instructed you to perform that mutation. GET requests do not need confirmation.",
+        `Make an authenticated GET request to the GrowthBook REST API. ` +
+        `Use path (+ optional query string) exactly as shown in skill workflows that mention gb-call GET. ` +
+        `Paths typically start with /api/v1/ or /api/v2/. Returns the raw response body on success. ` +
+        `Queries the GrowthBook REST API — see ${API_DOCS}.`,
       inputSchema: z.object({
-        method: z
-          .enum(["GET", "POST", "PUT", "PATCH", "DELETE"])
-          .describe("HTTP method"),
         path: z
           .string()
           .describe(
             "API path including query string if needed, e.g. /api/v1/projects or /api/v2/features/my-flag"
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ path }) => {
+      const result = await callApi({ method: "GET", path });
+      return {
+        content: [{ type: "text" as const, text: result.text }],
+        isError: !result.ok,
+      };
+    }
+  );
+
+  server.registerTool(
+    "growthbook_api_write",
+    {
+      title: "Write GrowthBook API",
+      description:
+        `Make an authenticated mutating request (POST, PUT, PATCH, or DELETE) to the GrowthBook REST API. ` +
+        `Use method + path (+ optional JSON body) exactly as shown in skill workflows that mention gb-call with those methods. ` +
+        `Paths typically start with /api/v1/ or /api/v2/. Returns the raw response body on success. ` +
+        `Mutates the GrowthBook REST API — see ${API_DOCS}.`,
+      inputSchema: z.object({
+        method: z
+          .enum(["POST", "PUT", "PATCH", "DELETE"])
+          .describe("HTTP method"),
+        path: z
+          .string()
+          .describe(
+            "API path including query string if needed, e.g. /api/v2/features or /api/v1/experiments/exp_123"
           ),
         body: z
           .string()
@@ -36,8 +68,8 @@ export function registerCallApiTool(server: McpServer) {
           ),
       }),
       annotations: {
-        // Can mutate org state depending on method/path
         readOnlyHint: false,
+        destructiveHint: true,
         openWorldHint: true,
       },
     },
@@ -68,7 +100,7 @@ export function registerSkillTools(server: McpServer) {
       description:
         "List available GrowthBook agent skills (name + description). " +
         "Use growthbook_read_skill to load the full workflow for a skill before acting. " +
-        "Skills encode how to accomplish GrowthBook tasks well; use growthbook_call_api to execute the REST calls they describe.",
+        "Skills encode how to accomplish GrowthBook tasks well; use growthbook_api_read / growthbook_api_write to execute the REST calls they describe.",
       inputSchema: z.object({}),
       annotations: {
         readOnlyHint: true,
@@ -90,7 +122,8 @@ export function registerSkillTools(server: McpServer) {
       description:
         "Return the full markdown content of a GrowthBook skill by name " +
         "(from growthbook_list_skills). Follow the skill's workflow; when it shows " +
-        "`gb-call <METHOD> <PATH> [body]`, use the growthbook_call_api tool with those arguments instead.",
+        "`gb-call <METHOD> <PATH> [body]`, use growthbook_api_read for GET and " +
+        "growthbook_api_write for POST/PUT/PATCH/DELETE.",
       inputSchema: z.object({
         name: z
           .string()


### PR DESCRIPTION
## Summary
- Tweaking MCP so that it conforms with claude directory requirements
- Replace `growthbook_call_api` with `growthbook_api_read` (GET) and `growthbook_api_write` (mutating methods) so MCP clients can honor read/write annotations
- Update skill bridge notes, server instructions, and package manifests for 2.1.0
