### PR TITLE
Address security vulnerabilities (2026-08-14)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,15 @@ FROM node:20-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 
+# Pick up Debian security patches (glibc, gnutls28, dpkg, etc.) ahead of the
+# next node:20-slim base refresh.
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev && npm cache clean --force
+# npm itself (and its vendored deps: tar, minimatch, brace-expansion, ...) is
+# only needed to install; it never runs once the container starts `node`.
+RUN npm ci --omit=dev && npm cache clean --force && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
 
 # Compiled server (includes the bundled skills under server/skills).
 COPY --from=build /build/server ./server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@growthbook/mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@growthbook/mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1622,9 +1622,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1792,9 +1792,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1843,9 +1843,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
### Features and Changes

Addresses this repo's 80 Vanta/Inspector findings via three independent fixes in one commit.

- **Debian OS packages.** Added `apt-get update && apt-get upgrade -y` to the Dockerfile runtime stage. `bookworm` already carries patched candidates for `glibc`, `gnutls28`, `dpkg`, `libcap2`, `libgcrypt20`, `systemd`, and `xz-utils` — verified directly against `node:20-slim` (amd64).
- **Removed npm from the runtime image.** `npm` (and its vendored deps — `tar`, `minimatch`, `brace-expansion`, `cross-spawn`, `diff`, `glob`, `sigstore`, `@sigstore/core`, an old `ip-address@9.0.5`) is only needed to install packages; the container's `CMD` runs `node server/index.js` directly and never shells out to `npm` again. The runtime stage now deletes `npm`/`npx`/`corepack` right after `npm ci --omit=dev` finishes.
- **Bumped transitive deps.** `hono`, `@hono/node-server`, `fast-uri`, and `ip-address` (real workspace deps, pulled in via `@modelcontextprotocol/sdk`, `ajv`, and `express-rate-limit`) move to their latest patched in-major releases via `npm update` — no `package.json` changes needed, the existing semver ranges already allowed it; the lockfile was just stale.

### Known issues

- `openssl/openssl` bundled inside the Node 20 binary (16 findings) is unaddressed — verified `node:20-slim`, `node:22-slim`, and `node:24-slim` (latest tags, amd64) still ship OpenSSL 3.0.19 / 3.5.4 / 3.5.7 respectively, none reaching the 3.6.2 needed. This is genuinely pending upstream Node, not something a rebuild clears. None of these are within the due-date danger window (earliest due 2026-08-28).

### Testing

- [x] `tsc` type-check — clean
- [x] `vitest run` — 24/24 tests pass
- [x] `docker build` — succeeds; built image confirmed `glibc` at `2.36-9+deb12u14` and `npm`/`npx` absent
- [x] Container boot smoke test — server starts and serves the MCP endpoint over HTTP

### Post-deploy projection

| Severity | Total findings | Addressed or auto-clears | Remaining | — of which pending upstream |
| -------- | -------------- | ------------------------- | --------- | ---------------------------- |
| CRITICAL | 4              | 2                          | 2         | 2                             |
| HIGH     | 45             | 35                         | 10        | 10                            |
| MEDIUM   | 27             | 24                         | 3         | 3                             |
| LOW      | 4              | 3                          | 1         | 1                             |
