### PR TITLE
Support structured and flat skill bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Skill bundling preserves each top-level skill tree (`<skill>/SKILL.md` + optional `<skill>/references/*.md`) instead of flattening entry points to `server/skills/<name>.md`
+- `growthbook_list_skills` lists top-level skill entry points; `growthbook_read_skill` accepts a listed name or qualified child path (e.g. `feature-flags/references/flag-create`)
+- At bundle time, in-skill `` `references/foo.md` `` links are rewritten to qualified paths (e.g. `` `feature-flags/references/foo` ``) so the runtime can serve files as-is
+
 ## [2.1.0] - 2026-08-10
 
 ### Breaking

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for the GrowthBook MCP server (HTTP transport).
 #
-# `npm run build` runs `bundle-skills`, which copies SKILL.md files from a
+# `npm run build` runs `bundle-skills`, which copies the top-level skill tree from a
 # checkout of github.com/growthbook/skills. That repo is NOT part of this build
 # context by default, so CI must vendor it into ./skills-src before building
 # (the deploy workflow does this via actions/checkout, matching ci.yml).
@@ -21,7 +21,7 @@ RUN npm ci
 COPY . .
 
 # Skills source, vendored into the context by CI (or a local clone). bundle-skills
-# reads <SKILLS_SRC>/skills/<name>/SKILL.md.
+# copies <SKILLS_SRC>/skills/<skill>/{SKILL.md,references/*.md}.
 ENV SKILLS_SRC=/build/skills-src
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A thin MCP server for GrowthBook with four tools:
 
 | Tool | Purpose |
 |------|---------|
-| `growthbook_list_skills` | List bundled GrowthBook agent skills (name + description) |
-| `growthbook_read_skill` | Return the full skill markdown (workflow + guardrails) |
+| `growthbook_list_skills` | List top-level skill entry points (name + description) |
+| `growthbook_read_skill` | Return a listed skill or qualified child workflow (`feature-flags` or `feature-flags/references/flag-create`) |
 | `growthbook_api_read` | Authenticated GET passthrough to the GrowthBook API |
 | `growthbook_api_write` | Authenticated POST/PUT/PATCH/DELETE passthrough |
 
@@ -108,14 +108,21 @@ When skills are disabled, only the API read/write tools are registered. `growthb
 npm run build   # tsc && bundle-skills
 ```
 
-`scripts/bundle-skills.mjs` copies every `skills/*/SKILL.md` from the canonical skills checkout into `server/skills/<name>.md`.
+`scripts/bundle-skills.mjs` copies the top-level skill tree from the canonical skills checkout, preserving structure:
+
+```
+skills/<skill>/SKILL.md                   → server/skills/<skill>/SKILL.md
+skills/<skill>/references/<workflow>.md   → server/skills/<skill>/references/<workflow>.md
+```
+
+Per-skill `scripts/` directories (the `gb-call` helper) are not copied — MCP uses the API tools instead.
 
 Source path resolution:
 
 1. `SKILLS_SRC` env var (path to the skills repo root), or
 2. `../skills` (sibling directory)
 
-The skills repo stays the source of truth — this package never forks skill content.
+The skills repo stays the source of truth — this package never forks skill content. At bundle time, in-skill `` `references/foo.md` `` links are rewritten to qualified paths (`` `feature-flags/references/foo` ``) so the on-disk MCP artifact is ready to serve.
 
 ## Using skills with the API tools
 
@@ -145,7 +152,10 @@ This MCP server does **not** shell out to `gb-call`. Map `GET` → `growthbook_a
 
 ### `growthbook_list_skills` / `growthbook_read_skill`
 
-Only registered when `GB_SKILLS_ENABLED` is not disabled. `growthbook_read_skill` returns the full `SKILL.md` content so the agent can follow workflow steps and guardrails.
+Only registered when `GB_SKILLS_ENABLED` is not disabled.
+
+- `growthbook_list_skills` returns top-level skill entry points. An entry may contain a complete workflow or route to child workflows.
+- `growthbook_read_skill` accepts a listed top-level name or a qualified child path named by a loaded skill (`feature-flags/references/flag-create`) and returns the full markdown (workflow + guardrails).
 
 ## Development
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
   },
   "homepage": "https://growthbook.io",
   "documentation": "https://docs.growthbook.io/integrations/mcp",
+  "icon": "icon.png",
   "server": {
     "type": "node",
     "entry_point": "server/index.js",
@@ -28,11 +29,11 @@
   "tools": [
     {
       "name": "growthbook_list_skills",
-      "description": "List available GrowthBook agent skills (name + description)."
+      "description": "List top-level GrowthBook skill entry points (name + description)."
     },
     {
       "name": "growthbook_read_skill",
-      "description": "Return the full markdown content of a GrowthBook skill by name."
+      "description": "Return skill markdown by top-level name or qualified child path (e.g. feature-flags/references/flag-create)."
     },
     {
       "name": "growthbook_api_read",

--- a/scripts/bundle-skills.mjs
+++ b/scripts/bundle-skills.mjs
@@ -1,33 +1,57 @@
 #!/usr/bin/env node
-// Copies each skills/<name>/SKILL.md from the canonical skills repo into
-// server/skills/<name>.md.
+// Copies the skills repo top-level layout into server/skills/, preserving structure:
+//
+//   <src>/skills/<skill>/SKILL.md
+//   <src>/skills/<skill>/references/*.md
+//     → server/skills/<skill>/SKILL.md
+//     → server/skills/<skill>/references/*.md
+//
+// Adapts content for MCP at bundle time:
+//   - skips per-skill scripts/ (gb-call symlinks)
+//   - rewrites `` `references/foo.md` `` → qualified growthbook_read_skill paths
 //
 // Source path resolution (first match wins):
 //   1. SKILLS_SRC env var
 //   2. ../skills (sibling of this repo)
-//
-// Expects the skills repo layout: <src>/skills/<name>/SKILL.md
 
 import {
-  cpSync,
   existsSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "..");
 const outDir = join(repoRoot, "server", "skills");
+
+/**
+ * Rewrite filesystem-relative `` `references/foo.md` `` links (skills-repo
+ * convention) into qualified read_skill paths for the given top-level skill.
+ * Tool name is omitted — agents already know to call growthbook_read_skill.
+ */
+export function rewriteReferencePaths(content, entrypoint) {
+  return content.replace(
+    /`references\/([^`\n]+?)\.md`/g,
+    (_match, file) => `\`${entrypoint}/references/${file}\``
+  );
+}
 
 function resolveSkillsSrc() {
   if (process.env.SKILLS_SRC) {
     return resolve(process.env.SKILLS_SRC);
   }
   return resolve(repoRoot, "..", "skills");
+}
+
+function writeAdaptedMarkdown(srcPath, destPath, entrypoint) {
+  const raw = readFileSync(srcPath, "utf8");
+  writeFileSync(destPath, rewriteReferencePaths(raw, entrypoint), "utf8");
 }
 
 function main() {
@@ -49,7 +73,9 @@ function main() {
     rmSync(join(outDir, entry), { recursive: true, force: true });
   }
 
-  let count = 0;
+  let entrypoints = 0;
+  let references = 0;
+
   for (const name of readdirSync(skillsDir)) {
     const skillDir = join(skillsDir, name);
     if (!statSync(skillDir).isDirectory()) continue;
@@ -60,17 +86,36 @@ function main() {
       continue;
     }
 
-    const dest = join(outDir, `${name}.md`);
-    cpSync(skillFile, dest);
-    count += 1;
+    const destDir = join(outDir, name);
+    mkdirSync(destDir, { recursive: true });
+    writeAdaptedMarkdown(skillFile, join(destDir, "SKILL.md"), name);
+    entrypoints += 1;
+
+    const refsDir = join(skillDir, "references");
+    if (existsSync(refsDir) && statSync(refsDir).isDirectory()) {
+      const destRefs = join(destDir, "references");
+      mkdirSync(destRefs, { recursive: true });
+      for (const file of readdirSync(refsDir)) {
+        if (!file.endsWith(".md")) continue;
+        writeAdaptedMarkdown(join(refsDir, file), join(destRefs, file), name);
+        references += 1;
+      }
+    }
   }
 
-  if (count === 0) {
+  if (entrypoints === 0) {
     console.error(`No SKILL.md files found under ${skillsDir}`);
     process.exit(1);
   }
 
-  console.log(`Bundled ${count} skill(s) from ${skillsDir} → ${outDir}`);
+  console.log(
+    `Bundled ${entrypoints} top-level skill(s) and ${references} reference(s) from ${skillsDir} → ${outDir}`
+  );
 }
 
-main();
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main();
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -4,6 +4,7 @@
  * Paths:
  * - POST /mcp      — full server (skills + API read/write tools), unless GB_SKILLS_ENABLED=false
  * - POST /mcp/api  — capability-only (growthbook_api_read + growthbook_api_write)
+ * - GET  /         — redirects a browser to the integration docs
  *
  * - Serves /.well-known/oauth-protected-resource (RFC 9728) pointing at the GB AS
  * - Requires Bearer; validates it against GrowthBook REST so expired/revoked
@@ -23,6 +24,9 @@ import {
   getOauthIssuer,
   requestAuthStore,
 } from "./api.js";
+
+/** Human-facing docs for this server: advertised in OAuth metadata and used by the / redirect. */
+const DOCS_URL = "https://docs.growthbook.io/integrations/mcp";
 
 export type CreateServerOptions = {
   /** When false, only growthbook_api_read / growthbook_api_write are registered. */
@@ -157,7 +161,7 @@ function createMcpHttpApp(options: McpHttpAppOptions): Express {
       authorization_servers: [getOauthIssuer()],
       bearer_methods_supported: ["header"],
       scopes_supported: ["openid", "profile", "email", "offline_access"],
-      resource_documentation: "https://docs.growthbook.io/integrations/mcp",
+      resource_documentation: DOCS_URL,
     });
   }
 
@@ -170,6 +174,15 @@ function createMcpHttpApp(options: McpHttpAppOptions): Express {
       })
     );
   }
+
+  // Nothing at the origin root speaks MCP — the protocol only defines the /mcp
+  // endpoints below — so anyone landing here is a human in a browser. Send them
+  // to the docs instead of Express's default "Cannot GET /". Temporary (302) so
+  // this can become a real landing page later without clients having cached a
+  // permanent redirect.
+  app.get("/", (_req, res) => {
+    res.redirect(DOCS_URL);
+  });
 
   // Unauthenticated liveness probe for load balancers / orchestrators. It does
   // not touch GrowthBook, so it stays green even if the upstream API is down —

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,16 +32,18 @@ function instructionsFor(skills: boolean): string {
     ? `You are a helpful assistant that interacts with GrowthBook via a thin MCP server.
 
 Tools:
-- growthbook_list_skills — discover available GrowthBook skills (name + description)
-- growthbook_read_skill — load a skill's full workflow and guardrails
+- growthbook_list_skills — discover top-level skill entry points (name + description)
+- growthbook_read_skill — load a listed skill or a qualified child path (e.g. feature-flags/references/flag-create)
 - growthbook_api_read — authenticated GET against the GrowthBook REST API
 - growthbook_api_write — authenticated POST/PUT/PATCH/DELETE against the GrowthBook REST API
 
 Workflow:
-1. growthbook_list_skills (or growthbook_read_skill if you already know the skill name) to load competence.
-2. Follow the skill's steps. Skills show bash like \`gb-call <METHOD> <PATH> [body]\` —
+1. Call growthbook_list_skills, then growthbook_read_skill with the matching top-level skill name.
+2. Follow the returned workflow directly. If it routes to a qualified child path
+   (e.g. feature-flags/references/flag-create), call growthbook_read_skill again with that path.
+3. Skills show bash like \`gb-call <METHOD> <PATH> [body]\` —
    map GET to growthbook_api_read and POST/PUT/PATCH/DELETE to growthbook_api_write with the same path and optional JSON body string.
-3. Do not invent endpoints; prefer the paths listed in the skill.
+4. Do not invent endpoints; prefer the paths listed in the skill.
 
 Skill content is the source of truth for GrowthBook task workflows and API footguns.
 growthbook_api_read / growthbook_api_write are dumb authenticated passthroughs — they do not validate payloads.`

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,10 +1,23 @@
 /**
- * Load and parse bundled GrowthBook skills (SKILL.md files copied at build time).
+ * Load and parse bundled GrowthBook skills (top-level skill tree copied at build time).
+ *
+ * Layout mirrors the skills repo:
+ *
+ *   server/skills/
+ *     feature-flags/
+ *       SKILL.md
+ *       references/
+ *         flag-create.md
+ *         ...
+ *     experiments/
+ *       ...
  */
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+export type SkillKind = "entrypoint" | "reference";
 
 export interface SkillSummary {
   name: string;
@@ -12,8 +25,11 @@ export interface SkillSummary {
 }
 
 export interface Skill extends SkillSummary {
-  /** Full markdown body including frontmatter */
+  /** Full markdown body including frontmatter (already MCP-adapted at bundle time). */
   content: string;
+  kind: SkillKind;
+  /** Top-level skill directory name (e.g. feature-flags or flag-create). */
+  entrypoint: string;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -75,7 +91,35 @@ export function parseFrontmatter(content: string): {
   return result;
 }
 
+/**
+ * Normalize a growthbook_read_skill name to a bundle path key.
+ * Accepts optional `.md`; rejects empty names and path traversal.
+ */
+export function normalizeSkillPath(name: string): string | null {
+  const trimmed = name.trim().replace(/\\/g, "/").replace(/\.md$/i, "");
+  if (!trimmed) return null;
+  if (trimmed.startsWith("/") || trimmed.split("/").includes("..")) {
+    return null;
+  }
+  return trimmed;
+}
+
 let cachedSkills: Skill[] | null = null;
+
+function loadSkillFile(
+  filePath: string,
+  name: string,
+  kind: SkillKind,
+  entrypoint: string
+): Skill {
+  const content = readFileSync(filePath, "utf8");
+  const meta = parseFrontmatter(content);
+  const description =
+    meta.description ||
+    `GrowthBook skill: ${name}. Call growthbook_read_skill for the full workflow.`;
+
+  return { name, description, content, kind, entrypoint };
+}
 
 export function loadSkills(): Skill[] {
   if (cachedSkills !== null) {
@@ -90,30 +134,50 @@ export function loadSkills(): Skill[] {
 
   const skills: Skill[] = [];
 
-  for (const file of readdirSync(skillsDir).sort()) {
-    if (!file.endsWith(".md")) continue;
+  for (const entrypoint of readdirSync(skillsDir).sort()) {
+    const skillDir = join(skillsDir, entrypoint);
+    if (!statSync(skillDir).isDirectory()) continue;
 
-    const content = readFileSync(join(skillsDir, file), "utf8");
-    const meta = parseFrontmatter(content);
-    const nameFromFile = file.replace(/\.md$/, "");
-    const name = meta.name || nameFromFile;
-    const description =
-      meta.description ||
-      `GrowthBook skill: ${name}. Call growthbook_read_skill for the full workflow.`;
+    const skillFile = join(skillDir, "SKILL.md");
+    if (!existsSync(skillFile)) continue;
 
-    skills.push({ name, description, content });
+    skills.push(
+      loadSkillFile(skillFile, entrypoint, "entrypoint", entrypoint)
+    );
+
+    const refsDir = join(skillDir, "references");
+    if (!existsSync(refsDir) || !statSync(refsDir).isDirectory()) continue;
+
+    for (const file of readdirSync(refsDir).sort()) {
+      if (!file.endsWith(".md")) continue;
+      const reference = file.replace(/\.md$/i, "");
+      const name = `${entrypoint}/references/${reference}`;
+      skills.push(
+        loadSkillFile(join(refsDir, file), name, "reference", entrypoint)
+      );
+    }
   }
 
   cachedSkills = skills;
   return skills;
 }
 
+/** Top-level entry points only; referenced workflows load via read_skill. */
 export function listSkillSummaries(): SkillSummary[] {
-  return loadSkills().map(({ name, description }) => ({ name, description }));
+  return loadSkills()
+    .filter((s) => s.kind === "entrypoint")
+    .map(({ name, description }) => ({ name, description }));
 }
 
 export function getSkill(name: string): Skill | undefined {
-  return loadSkills().find((s) => s.name === name);
+  const pathKey = normalizeSkillPath(name);
+  if (!pathKey) return undefined;
+  return loadSkills().find((s) => s.name === pathKey);
+}
+
+/** Content to return from growthbook_read_skill (bridge note + bundled markdown). */
+export function formatSkillForMcp(skill: Skill): string {
+  return GB_CALL_BRIDGE_NOTE + skill.content;
 }
 
 /** Bridge note prepended when returning skill content via growthbook_read_skill. */
@@ -122,3 +186,8 @@ export const GB_CALL_BRIDGE_NOTE = `> **MCP note:** This skill's workflow exampl
 > with the same path and optional JSON body string. Do not shell out to \`gb-call\`.
 
 `;
+
+/** Test helper — clears the in-memory skill cache. */
+export function resetSkillsCache(): void {
+  cachedSkills = null;
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,7 +2,7 @@ import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { callApi } from "./api.js";
 import {
-  GB_CALL_BRIDGE_NOTE,
+  formatSkillForMcp,
   getSkill,
   listSkillSummaries,
   loadSkills,
@@ -98,8 +98,10 @@ export function registerSkillTools(server: McpServer) {
     {
       title: "List GrowthBook Skills",
       description:
-        "List available GrowthBook agent skills (name + description). " +
-        "Use growthbook_read_skill to load the full workflow for a skill before acting. " +
+        "List available top-level GrowthBook skill entry points (name + description). " +
+        "Call growthbook_read_skill with the relevant name. If the returned skill " +
+        "routes to a qualified child path (e.g. feature-flags/references/flag-create), " +
+        "call growthbook_read_skill again with that path. " +
         "Skills encode how to accomplish GrowthBook tasks well; use growthbook_api_read / growthbook_api_write to execute the REST calls they describe.",
       inputSchema: z.object({}),
       annotations: {
@@ -120,14 +122,19 @@ export function registerSkillTools(server: McpServer) {
     {
       title: "Read GrowthBook Skill",
       description:
-        "Return the full markdown content of a GrowthBook skill by name " +
-        "(from growthbook_list_skills). Follow the skill's workflow; when it shows " +
-        "`gb-call <METHOD> <PATH> [body]`, use growthbook_api_read for GET and " +
-        "growthbook_api_write for POST/PUT/PATCH/DELETE.",
+        "Return the full markdown content of a GrowthBook skill by path. " +
+        "Pass a top-level name from growthbook_list_skills (e.g. feature-flags or " +
+        "flag-create), or a qualified child path named by a skill " +
+        "(e.g. feature-flags/references/flag-create). " +
+        "Follow the skill's workflow; when it shows `gb-call <METHOD> <PATH> [body]`, " +
+        "use growthbook_api_read for GET and growthbook_api_write for POST/PUT/PATCH/DELETE.",
       inputSchema: z.object({
         name: z
           .string()
-          .describe("Skill name, e.g. flag-create or experiment-launch"),
+          .describe(
+            "Top-level skill name (e.g. feature-flags or flag-create), or a " +
+              "qualified child path named by a skill"
+          ),
       }),
       annotations: {
         readOnlyHint: true,
@@ -144,9 +151,10 @@ export function registerSkillTools(server: McpServer) {
             {
               type: "text" as const,
               text:
-                `Unknown skill: ${name}.` +
+                `Unknown skill: ${name}. ` +
+                `Use a name from growthbook_list_skills or a qualified child path named by a loaded skill.` +
                 (available
-                  ? ` Available skills: ${available}`
+                  ? ` Available top-level skills: ${available}`
                   : " No skills are bundled."),
             },
           ],
@@ -158,7 +166,7 @@ export function registerSkillTools(server: McpServer) {
         content: [
           {
             type: "text" as const,
-            text: GB_CALL_BRIDGE_NOTE + skill.content,
+            text: formatSkillForMcp(skill),
           },
         ],
       };

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { parseFrontmatter } from "../src/skills.js";
+import { rewriteReferencePaths } from "../scripts/bundle-skills.mjs";
+import { normalizeSkillPath, parseFrontmatter } from "../src/skills.js";
 
 describe("parseFrontmatter", () => {
   it("parses name and description", () => {
@@ -30,5 +31,46 @@ description: 'Create a feature flag'
 
   it("returns empty object when frontmatter is missing", () => {
     expect(parseFrontmatter("# No frontmatter\n")).toEqual({});
+  });
+});
+
+describe("normalizeSkillPath", () => {
+  it("strips .md and normalizes separators", () => {
+    expect(normalizeSkillPath("feature-flags/references/flag-create.md")).toBe(
+      "feature-flags/references/flag-create"
+    );
+    expect(normalizeSkillPath("feature-flags\\references\\flag-create")).toBe(
+      "feature-flags/references/flag-create"
+    );
+  });
+
+  it("rejects path traversal and empty names", () => {
+    expect(normalizeSkillPath("../secrets")).toBeNull();
+    expect(normalizeSkillPath("feature-flags/../experiments")).toBeNull();
+    expect(normalizeSkillPath("")).toBeNull();
+    expect(normalizeSkillPath("   ")).toBeNull();
+    expect(normalizeSkillPath("/feature-flags")).toBeNull();
+  });
+});
+
+describe("rewriteReferencePaths", () => {
+  it("rewrites backtick references to qualified paths", () => {
+    const input = `Read \`references/flag-create.md\` then \`references/flag-publish.md\`.`;
+    expect(rewriteReferencePaths(input, "feature-flags")).toBe(
+      "Read `feature-flags/references/flag-create` then `feature-flags/references/flag-publish`."
+    );
+  });
+
+  it("leaves bare workflow names and cross-skill prose alone", () => {
+    const input =
+      "Start at `experiment-design`. Use the **experiments** skill.";
+    expect(rewriteReferencePaths(input, "experiments")).toBe(input);
+  });
+
+  it("scopes rewrites to the top-level skill", () => {
+    const input = "See `references/metric-search.md`.";
+    expect(rewriteReferencePaths(input, "analytics")).toBe(
+      "See `analytics/references/metric-search`."
+    );
   });
 });


### PR DESCRIPTION
## What changed

The GrowthBook skills repo is moving from one folder per workflow to grouped skills. For example, feature flag workflows now live under a `feature-flags` skill, with individual workflows such as `flag-create` in its `references` folder.

This PR updates the MCP server so it can bundle and read that new structure:

- the build now copies both each top-level `SKILL.md` and any markdown files in its `references` folder
- `growthbook_list_skills` lists the top-level skills
- `growthbook_read_skill` can read either a top-level skill such as `feature-flags` or a workflow such as `feature-flags/references/flag-create`
- links between workflows are rewritten during the build so agents can follow them through the MCP tools

The previous flat skills layout still works, so this can be merged before the skills repo changes. The tool instructions handle both layouts: a top-level skill may contain the complete workflow, or it may direct the agent to a workflow under `references`.

This also adds the GrowthBook icon to the MCP manifest and redirects the HTTP server root to the MCP integration documentation.

## Test plan

- [x] Run `npm test` (29 tests)
- [x] Run the TypeScript type-check
- [x] Build and use the MCP server with the previous flat skills checkout
- [x] Build and use the MCP server with the new grouped skills checkout
- [x] Run `git diff --check`